### PR TITLE
Implement FE-15 announcement edit flow and auth-gated home routing

### DIFF
--- a/frontend/src/app/announcement-list/announcement-list.component.css
+++ b/frontend/src/app/announcement-list/announcement-list.component.css
@@ -143,6 +143,83 @@
   font-weight: 600;
 }
 
+.edit-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 40;
+}
+
+.edit-modal {
+  position: fixed;
+  z-index: 41;
+  top: 50%;
+  left: 50%;
+  width: min(680px, calc(100vw - 2rem));
+  transform: translate(-50%, -50%);
+  background: #ffffff;
+  border-radius: 14px;
+  border: 1px solid #dbe1e8;
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.18);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.edit-modal h3 {
+  margin: 0;
+  color: #101828;
+}
+
+.edit-modal input,
+.edit-modal textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.68rem 0.72rem;
+  font: inherit;
+  color: #1f2937;
+  box-sizing: border-box;
+}
+
+.edit-modal textarea {
+  resize: vertical;
+  min-height: 132px;
+}
+
+.edit-modal input:focus,
+.edit-modal textarea:focus {
+  outline: 2px solid #c9f2d8;
+  border-color: #60a575;
+}
+
+.edit-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.edit-modal-actions button {
+  border: none;
+  border-radius: 999px;
+  background: #2e7d32;
+  color: #ffffff;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.edit-modal-actions button.secondary {
+  background: #edf2f7;
+  color: #344054;
+}
+
+.edit-modal-actions button:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
 @media (max-width: 768px) {
   .create-post-box {
     padding: 0.85rem;

--- a/frontend/src/app/announcement-list/announcement-list.component.html
+++ b/frontend/src/app/announcement-list/announcement-list.component.html
@@ -1,6 +1,6 @@
 <section class="announcement-list" aria-label="Announcement feed">
   <form class="create-post-box" (ngSubmit)="createPost()">
-    <div class="composer-avatar" aria-hidden="true">YO</div>
+    <div class="composer-avatar" aria-hidden="true">{{ composerInitials }}</div>
     <div class="composer-content">
       <input
         id="new-post-title"
@@ -32,7 +32,7 @@
 
   <app-post-card
     *ngFor="let announcement of filteredAnnouncements; trackBy: trackById"
-    [author]="announcement.author || fallbackAuthor"
+    [author]="getAuthorDisplayName(announcement)"
     [timestamp]="formatTimestamp(announcement.created_at)"
     [title]="announcement.title"
     [category]="'General'"
@@ -40,5 +40,37 @@
     [comments]="0"
     [imageAlt]="'Announcement image'"
     [content]="announcement.content"
+    [canEdit]="isOwnedByCurrentUser(announcement)"
+    (editClicked)="openEditModal(announcement)"
   />
+
+  <div class="edit-modal-backdrop" *ngIf="isEditModalOpen" (click)="closeEditModal()"></div>
+  <section class="edit-modal" *ngIf="isEditModalOpen" aria-label="Edit announcement">
+    <h3>Edit Announcement</h3>
+    <input
+      id="edit-post-title"
+      name="editPostTitle"
+      [(ngModel)]="editTitle"
+      placeholder="Announcement title"
+      maxlength="120"
+    />
+    <textarea
+      id="edit-post-content"
+      name="editPostContent"
+      [(ngModel)]="editContent"
+      rows="5"
+      placeholder="Edit announcement details"
+    ></textarea>
+
+    <p class="error-state submit-error" *ngIf="editErrorMessage">{{ editErrorMessage }}</p>
+
+    <div class="edit-modal-actions">
+      <button type="button" class="secondary" (click)="closeEditModal()" [disabled]="isUpdatingAnnouncement">
+        Cancel
+      </button>
+      <button type="button" (click)="saveEdit()" [disabled]="isUpdatingAnnouncement">
+        {{ isUpdatingAnnouncement ? 'Saving...' : 'Save Changes' }}
+      </button>
+    </div>
+  </section>
 </section>

--- a/frontend/src/app/announcement-list/announcement-list.component.spec.ts
+++ b/frontend/src/app/announcement-list/announcement-list.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { of, Subject, throwError } from 'rxjs';
 import { AnnouncementListComponent } from './announcement-list.component';
 import { AnnouncementService } from '../services/announcement.service';
+import { AuthService } from '../services/auth.service';
 
 describe('AnnouncementListComponent', () => {
   const mockAnnouncements = [
@@ -18,12 +19,22 @@ describe('AnnouncementListComponent', () => {
   ];
   const announcementServiceStub = {
     getAnnouncements: () => of(mockAnnouncements),
-    createAnnouncement: () => of(mockAnnouncements[0])
+    createAnnouncement: () => of(mockAnnouncements[0]),
+    updateAnnouncement: () => of(mockAnnouncements[0])
+  };
+  const authServiceStub = {
+    getStoredUser: () => ({
+      id: 1,
+      name: 'Yash O',
+      email: 'yash@example.com',
+      created_at: '2026-03-03T20:50:00Z'
+    })
   };
 
   beforeEach(async () => {
     announcementServiceStub.getAnnouncements = () => of(mockAnnouncements);
     announcementServiceStub.createAnnouncement = () => of(mockAnnouncements[0]);
+    announcementServiceStub.updateAnnouncement = () => of(mockAnnouncements[0]);
 
     await TestBed.configureTestingModule({
       imports: [AnnouncementListComponent],
@@ -31,6 +42,10 @@ describe('AnnouncementListComponent', () => {
         {
           provide: AnnouncementService,
           useValue: announcementServiceStub
+        },
+        {
+          provide: AuthService,
+          useValue: authServiceStub
         }
       ]
     }).compileComponents();
@@ -198,5 +213,59 @@ describe('AnnouncementListComponent', () => {
 
     expect(component.isSubmitting).toBe(false);
     expect(component.submitErrorMessage).toBe('You must be logged in to post an announcement.');
+  });
+
+  it('should map current user id author to current user display name', () => {
+    const fixture = TestBed.createComponent(AnnouncementListComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const displayName = component.getAuthorDisplayName({
+      id: 8,
+      title: 'Test',
+      content: 'Test',
+      author: '1',
+      created_at: '2026-03-03T20:50:00Z'
+    });
+
+    expect(displayName).toBe('Yash O');
+    expect(component.isOwnedByCurrentUser({
+      id: 8,
+      title: 'Test',
+      content: 'Test',
+      author: '1',
+      created_at: '2026-03-03T20:50:00Z'
+    })).toBe(true);
+  });
+
+  it('should open edit modal and update announcement on save', () => {
+    const updatedAnnouncement = {
+      id: 1,
+      title: 'Updated title',
+      author: '1',
+      content: 'Updated content',
+      created_at: '2026-03-03T20:50:00Z',
+      updated_at: '2026-03-24T20:50:00Z',
+      deleted_at: null
+    };
+    announcementServiceStub.updateAnnouncement = () => of(updatedAnnouncement);
+
+    const fixture = TestBed.createComponent(AnnouncementListComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.announcements = component.announcements.map((announcement) => ({
+      ...announcement,
+      author: '1'
+    }));
+
+    component.openEditModal(component.announcements[0]);
+    component.editTitle = 'Updated title';
+    component.editContent = 'Updated content';
+    component.saveEdit();
+
+    expect(component.isEditModalOpen).toBe(false);
+    expect(component.announcements[0].title).toBe('Updated title');
+    expect(component.announcements[0].content).toBe('Updated content');
   });
 });

--- a/frontend/src/app/announcement-list/announcement-list.component.ts
+++ b/frontend/src/app/announcement-list/announcement-list.component.ts
@@ -5,10 +5,12 @@ import { FormsModule } from '@angular/forms';
 import { catchError, finalize, map, of, retry, switchMap } from 'rxjs';
 import { PostCardComponent } from '../post-card/post-card.component';
 import { SearchService } from '../services/search.service';
+import { AuthService } from '../services/auth.service';
 import {
   AnnouncementService,
   Announcement,
-  CreateAnnouncementPayload
+  CreateAnnouncementPayload,
+  UpdateAnnouncementPayload
 } from '../services/announcement.service';
 
 @Component({
@@ -25,6 +27,7 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
   private destroyed = false;
   constructor(
     private readonly searchService: SearchService,
+    private readonly authService: AuthService,
     private readonly announcementService: AnnouncementService,
     private readonly cdr: ChangeDetectorRef
   ) {}
@@ -36,8 +39,17 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
   submitErrorMessage = '';
   newPostTitle = '';
   newPostContent = '';
+  currentUserId = '';
+  currentUserName = '';
+  isEditModalOpen = false;
+  isUpdatingAnnouncement = false;
+  editErrorMessage = '';
+  editingAnnouncementId: number | null = null;
+  editTitle = '';
+  editContent = '';
 
   ngOnInit(): void {
+    this.loadCurrentUserContext();
     this.fetchAnnouncements();
   }
 
@@ -129,8 +141,107 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
       });
   }
 
+  openEditModal(announcement: Announcement): void {
+    if (!this.isOwnedByCurrentUser(announcement)) {
+      return;
+    }
+
+    this.editingAnnouncementId = announcement.id;
+    this.editTitle = announcement.title;
+    this.editContent = announcement.content;
+    this.editErrorMessage = '';
+    this.isEditModalOpen = true;
+  }
+
+  closeEditModal(): void {
+    this.isEditModalOpen = false;
+    this.isUpdatingAnnouncement = false;
+    this.editErrorMessage = '';
+    this.editingAnnouncementId = null;
+    this.editTitle = '';
+    this.editContent = '';
+  }
+
+  saveEdit(): void {
+    if (!this.editingAnnouncementId || this.isUpdatingAnnouncement) {
+      return;
+    }
+
+    const payload: UpdateAnnouncementPayload = {
+      id: this.editingAnnouncementId,
+      title: this.editTitle.trim(),
+      content: this.editContent.trim()
+    };
+
+    if (!payload.title || !payload.content) {
+      this.editErrorMessage = 'Title and content are required.';
+      this.safeDetectChanges();
+      return;
+    }
+
+    this.isUpdatingAnnouncement = true;
+    this.editErrorMessage = '';
+
+    this.announcementService
+      .updateAnnouncement(payload)
+      .pipe(
+        finalize(() => {
+          this.isUpdatingAnnouncement = false;
+          this.safeDetectChanges();
+        })
+      )
+      .subscribe({
+        next: (updated) => {
+          this.announcements = this.sortAnnouncements(
+            this.announcements.map((announcement) =>
+              announcement.id === updated.id ? updated : announcement
+            )
+          );
+          this.closeEditModal();
+          this.safeDetectChanges();
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.editErrorMessage = this.getUpdateErrorMessage(error);
+          this.safeDetectChanges();
+        }
+      });
+  }
+
   trackById(_index: number, announcement: Announcement): number {
     return announcement.id;
+  }
+
+  isOwnedByCurrentUser(announcement: Announcement): boolean {
+    if (!this.currentUserId) {
+      return false;
+    }
+    return announcement.author === this.currentUserId;
+  }
+
+  getAuthorDisplayName(announcement: Announcement): string {
+    if (!announcement.author) {
+      return this.fallbackAuthor;
+    }
+
+    if (announcement.author === this.currentUserId && this.currentUserName) {
+      return this.currentUserName;
+    }
+
+    if (/^\d+$/.test(announcement.author)) {
+      return `User ${announcement.author}`;
+    }
+
+    return announcement.author;
+  }
+
+  get composerInitials(): string {
+    const source = this.currentUserName.trim() || this.fallbackAuthor;
+    const names = source.split(' ').filter(Boolean);
+    return names
+      .slice(0, 2)
+      .map((name) => name.charAt(0).toUpperCase())
+      .join('');
   }
 
   get filteredAnnouncements(): Announcement[] {
@@ -141,7 +252,7 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
     return this.announcements.filter(announcement =>
       announcement.title.toLowerCase().includes(query) ||
       announcement.content.toLowerCase().includes(query) ||
-      announcement.author.toLowerCase().includes(query)
+      this.getAuthorDisplayName(announcement).toLowerCase().includes(query)
     );
   }
 
@@ -185,6 +296,41 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
     return 'Failed to create announcement. Please try again.';
   }
 
+  private getUpdateErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to update announcement. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to edit announcements.';
+    }
+
+    if (error.status === 403) {
+      return 'You can only edit your own announcements.';
+    }
+
+    if (error.status === 404) {
+      return 'Announcement not found.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to update announcement. Please try again.';
+  }
+
   private sortAnnouncements(announcements: Announcement[]): Announcement[] {
     return [...announcements].sort((a, b) => {
       const timestampA = this.getTimestampValue(a.created_at);
@@ -202,6 +348,18 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
       return 0;
     }
     return parsed;
+  }
+
+  private loadCurrentUserContext(): void {
+    const user = this.authService.getStoredUser();
+    if (!user) {
+      this.currentUserId = '';
+      this.currentUserName = '';
+      return;
+    }
+
+    this.currentUserId = `${user.id}`;
+    this.currentUserName = user.name?.trim() ?? '';
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { EventsComponent } from './pages/events/events.component';
 import { LayoutComponent } from './layout/layout.component';
 import { SignupComponent } from './pages/signup/signup.component';
 import { LoginComponent } from './pages/login/login.component';
+import { authGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
   { path: 'signup', component: SignupComponent },
@@ -12,6 +13,7 @@ export const routes: Routes = [
   {
     path: '',
     component: LayoutComponent,
+    canActivate: [authGuard],
     children: [
       { path: '', component: HomeComponent },
       { path: 'alerts', component: AlertsComponent },

--- a/frontend/src/app/guards/auth.guard.ts
+++ b/frontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/src/app/post-card/post-card.component.css
+++ b/frontend/src/app/post-card/post-card.component.css
@@ -41,8 +41,24 @@
   font-size: 0.86rem;
 }
 
-.category-badge {
+.edit-btn {
   margin-left: auto;
+  border: 1px solid #bfd7c8;
+  background: #f3faf6;
+  color: #0f7a43;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.3rem 0.72rem;
+  cursor: pointer;
+}
+
+.edit-btn:hover {
+  background: #e8f7ee;
+}
+
+.category-badge {
+  margin-left: 0.5rem;
   background: #eef2f7;
   color: #4b5563;
   font-size: 0.75rem;

--- a/frontend/src/app/post-card/post-card.component.html
+++ b/frontend/src/app/post-card/post-card.component.html
@@ -5,6 +5,15 @@
       <h3>{{ author }}</h3>
       <p>{{ timestamp }}</p>
     </div>
+    <button
+      *ngIf="canEdit"
+      type="button"
+      class="edit-btn"
+      aria-label="Edit your announcement"
+      (click)="onEditClick()"
+    >
+      Edit
+    </button>
     <span class="category-badge">{{ category }}</span>
   </header>
 

--- a/frontend/src/app/post-card/post-card.component.ts
+++ b/frontend/src/app/post-card/post-card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-post-card',
@@ -18,6 +18,8 @@ export class PostCardComponent {
   @Input() imageAlt = 'Post image';
   @Input() likes = 0;
   @Input() comments = 0;
+  @Input() canEdit = false;
+  @Output() editClicked = new EventEmitter<void>();
 
   get authorInitials(): string {
     const names = this.author.trim().split(' ').filter(Boolean);
@@ -28,5 +30,9 @@ export class PostCardComponent {
       .slice(0, 2)
       .map((name) => name.charAt(0).toUpperCase())
       .join('');
+  }
+
+  onEditClick(): void {
+    this.editClicked.emit();
   }
 }

--- a/frontend/src/app/services/announcement.service.spec.ts
+++ b/frontend/src/app/services/announcement.service.spec.ts
@@ -120,4 +120,58 @@ describe('AnnouncementService', () => {
       deleted_at: null
     });
   });
+
+  it('updates announcement with bearer token and normalizes response payload', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-456');
+
+    let postedUrl = '';
+    let postedBody: unknown;
+    const postedHeaders: { Authorization?: string } = {};
+    const httpClientStub = {
+      get: () => of([]),
+      post: (url: string, body: unknown, options?: { headers?: { get(name: string): string | null } }) => {
+        postedUrl = url;
+        postedBody = body;
+        const auth = options?.headers?.get('Authorization');
+        if (auth) {
+          postedHeaders['Authorization'] = auth;
+        }
+        return of({
+          ID: 11,
+          Title: 'UPDATED: Community Meeting Friday',
+          Content: 'The meeting time has moved to 7 PM.',
+          Author: '1',
+          CreatedAt: '2026-03-03T20:50:00Z',
+          UpdatedAt: '2026-03-24T12:20:00Z',
+          DeletedAt: null
+        });
+      }
+    } as unknown as HttpClient;
+
+    const service = new AnnouncementService(httpClientStub);
+    const updated = await firstValueFrom(
+      service.updateAnnouncement({
+        id: 11,
+        title: 'UPDATED: Community Meeting Friday',
+        content: 'The meeting time has moved to 7 PM.'
+      })
+    );
+
+    expect(postedUrl).toBe('/api/announcements/update');
+    expect(postedBody).toEqual({
+      id: 11,
+      title: 'UPDATED: Community Meeting Friday',
+      content: 'The meeting time has moved to 7 PM.'
+    });
+    expect(postedHeaders['Authorization']).toBe('Bearer jwt-token-456');
+    expect(updated).toEqual({
+      id: 11,
+      title: 'UPDATED: Community Meeting Friday',
+      content: 'The meeting time has moved to 7 PM.',
+      author: '1',
+      created_at: '2026-03-03T20:50:00Z',
+      updated_at: '2026-03-24T12:20:00Z',
+      deleted_at: null
+    });
+  });
 });

--- a/frontend/src/app/services/announcement.service.ts
+++ b/frontend/src/app/services/announcement.service.ts
@@ -35,6 +35,12 @@ export interface CreateAnnouncementPayload {
   content: string;
 }
 
+export interface UpdateAnnouncementPayload {
+  id: number;
+  title?: string;
+  content?: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -73,6 +79,19 @@ export class AnnouncementService {
 
     return this.http
       .post<RawAnnouncement>(this.apiUrl, payload, { headers })
+      .pipe(map((raw) => this.normalizeAnnouncement(raw)));
+  }
+
+  updateAnnouncement(payload: UpdateAnnouncementPayload): Observable<Announcement> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http
+      .post<RawAnnouncement>(`${this.apiUrl}/update`, payload, { headers })
       .pipe(map((raw) => this.normalizeAnnouncement(raw)));
   }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -72,4 +72,25 @@ export class AuthService {
     localStorage.removeItem(this.tokenKey);
     localStorage.removeItem(this.userKey);
   }
+
+  getAuthToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  getStoredUser(): LoginUser | null {
+    const raw = localStorage.getItem(this.userKey);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as LoginUser;
+    } catch {
+      return null;
+    }
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getAuthToken();
+  }
 }


### PR DESCRIPTION
## Summary
Implemented edit announcement functionality and integrated with backend API.

## Changes
- Added edit button for user’s announcements
- Implemented edit form/modal
- Connected to backend update API
- Sent auth token with request
- Updated UI after successful edit

## Behavior
- Users can edit their own announcements
- Updated content is reflected in UI
- Only authorized users can edit
- Errors handled and displayed properly

## Preview
<img width="1212" height="875" alt="Screenshot 2026-03-24 at 4 40 33 PM" src="https://github.com/user-attachments/assets/d03398ac-e782-427c-b0a4-cba51b0c12d8" />

<img width="1213" height="876" alt="Screenshot 2026-03-24 at 4 40 54 PM" src="https://github.com/user-attachments/assets/733da075-3e8f-418e-a399-36711c564004" />

Closes #55