### PR TITLE
FE-16: add delete announcement flow with confirm and UI updates

### DIFF
--- a/frontend/src/app/announcement-list/announcement-list.component.html
+++ b/frontend/src/app/announcement-list/announcement-list.component.html
@@ -29,6 +29,7 @@
 
   <p class="load-state" *ngIf="isLoading">Loading announcements...</p>
   <p class="error-state" *ngIf="errorMessage">{{ errorMessage }}</p>
+  <p class="error-state" *ngIf="deleteErrorMessage">{{ deleteErrorMessage }}</p>
 
   <app-post-card
     *ngFor="let announcement of filteredAnnouncements; trackBy: trackById"
@@ -41,7 +42,10 @@
     [imageAlt]="'Announcement image'"
     [content]="announcement.content"
     [canEdit]="isOwnedByCurrentUser(announcement)"
+    [canDelete]="isOwnedByCurrentUser(announcement)"
+    [isDeleting]="isDeletingAnnouncementId === announcement.id"
     (editClicked)="openEditModal(announcement)"
+    (deleteClicked)="deleteAnnouncement(announcement)"
   />
 
   <div class="edit-modal-backdrop" *ngIf="isEditModalOpen" (click)="closeEditModal()"></div>

--- a/frontend/src/app/announcement-list/announcement-list.component.spec.ts
+++ b/frontend/src/app/announcement-list/announcement-list.component.spec.ts
@@ -20,7 +20,8 @@ describe('AnnouncementListComponent', () => {
   const announcementServiceStub = {
     getAnnouncements: () => of(mockAnnouncements),
     createAnnouncement: () => of(mockAnnouncements[0]),
-    updateAnnouncement: () => of(mockAnnouncements[0])
+    updateAnnouncement: () => of(mockAnnouncements[0]),
+    deleteAnnouncement: () => of({ message: 'Announcement deleted successfully' })
   };
   const authServiceStub = {
     getStoredUser: () => ({
@@ -35,6 +36,7 @@ describe('AnnouncementListComponent', () => {
     announcementServiceStub.getAnnouncements = () => of(mockAnnouncements);
     announcementServiceStub.createAnnouncement = () => of(mockAnnouncements[0]);
     announcementServiceStub.updateAnnouncement = () => of(mockAnnouncements[0]);
+    announcementServiceStub.deleteAnnouncement = () => of({ message: 'Announcement deleted successfully' });
 
     await TestBed.configureTestingModule({
       imports: [AnnouncementListComponent],
@@ -267,5 +269,57 @@ describe('AnnouncementListComponent', () => {
     expect(component.isEditModalOpen).toBe(false);
     expect(component.announcements[0].title).toBe('Updated title');
     expect(component.announcements[0].content).toBe('Updated content');
+  });
+
+  it('should delete owned announcement after confirmation', () => {
+    const originalConfirm = window.confirm;
+    window.confirm = () => true;
+
+    try {
+      const fixture = TestBed.createComponent(AnnouncementListComponent);
+      const component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      component.announcements = component.announcements.map((announcement) => ({
+        ...announcement,
+        author: '1'
+      }));
+
+      component.deleteAnnouncement(component.announcements[0]);
+
+      expect(component.announcements.length).toBe(0);
+      expect(component.deleteErrorMessage).toBe('');
+    } finally {
+      window.confirm = originalConfirm;
+    }
+  });
+
+  it('should not delete when confirmation is canceled', () => {
+    const originalConfirm = window.confirm;
+    window.confirm = () => false;
+
+    try {
+      let deleteCalled = false;
+      announcementServiceStub.deleteAnnouncement = () => {
+        deleteCalled = true;
+        return of({ message: 'Announcement deleted successfully' });
+      };
+
+      const fixture = TestBed.createComponent(AnnouncementListComponent);
+      const component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      component.announcements = component.announcements.map((announcement) => ({
+        ...announcement,
+        author: '1'
+      }));
+
+      component.deleteAnnouncement(component.announcements[0]);
+
+      expect(deleteCalled).toBe(false);
+      expect(component.announcements.length).toBe(1);
+    } finally {
+      window.confirm = originalConfirm;
+    }
   });
 });

--- a/frontend/src/app/announcement-list/announcement-list.component.ts
+++ b/frontend/src/app/announcement-list/announcement-list.component.ts
@@ -43,7 +43,9 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
   currentUserName = '';
   isEditModalOpen = false;
   isUpdatingAnnouncement = false;
+  isDeletingAnnouncementId: number | null = null;
   editErrorMessage = '';
+  deleteErrorMessage = '';
   editingAnnouncementId: number | null = null;
   editTitle = '';
   editContent = '';
@@ -208,6 +210,47 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
       });
   }
 
+  deleteAnnouncement(announcement: Announcement): void {
+    if (!this.isOwnedByCurrentUser(announcement)) {
+      return;
+    }
+
+    if (this.isDeletingAnnouncementId === announcement.id) {
+      return;
+    }
+
+    const confirmed = window.confirm('Are you sure you want to delete this announcement?');
+    if (!confirmed) {
+      return;
+    }
+
+    this.isDeletingAnnouncementId = announcement.id;
+    this.deleteErrorMessage = '';
+
+    this.announcementService
+      .deleteAnnouncement({ id: announcement.id })
+      .pipe(
+        finalize(() => {
+          this.isDeletingAnnouncementId = null;
+          this.safeDetectChanges();
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.announcements = this.announcements.filter((item) => item.id !== announcement.id);
+          if (this.editingAnnouncementId === announcement.id) {
+            this.closeEditModal();
+          }
+          this.safeDetectChanges();
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.deleteErrorMessage = this.getDeleteErrorMessage(error);
+          this.safeDetectChanges();
+        }
+      });
+  }
+
   trackById(_index: number, announcement: Announcement): number {
     return announcement.id;
   }
@@ -329,6 +372,41 @@ export class AnnouncementListComponent implements OnInit, OnDestroy {
     }
 
     return 'Failed to update announcement. Please try again.';
+  }
+
+  private getDeleteErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to delete announcement. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to delete announcements.';
+    }
+
+    if (error.status === 403) {
+      return 'You can only delete your own announcements.';
+    }
+
+    if (error.status === 404) {
+      return 'Announcement not found.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to delete announcement. Please try again.';
   }
 
   private sortAnnouncements(announcements: Announcement[]): Announcement[] {

--- a/frontend/src/app/post-card/post-card.component.css
+++ b/frontend/src/app/post-card/post-card.component.css
@@ -42,7 +42,6 @@
 }
 
 .edit-btn {
-  margin-left: auto;
   border: 1px solid #bfd7c8;
   background: #f3faf6;
   color: #0f7a43;
@@ -57,8 +56,35 @@
   background: #e8f7ee;
 }
 
+.delete-btn {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #b42318;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.3rem 0.72rem;
+  cursor: pointer;
+}
+
+.delete-btn:hover {
+  background: #fee2e2;
+}
+
+.delete-btn:disabled {
+  opacity: 0.8;
+  cursor: default;
+}
+
+.owner-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .category-badge {
-  margin-left: 0.5rem;
+  margin-left: 0.35rem;
   background: #eef2f7;
   color: #4b5563;
   font-size: 0.75rem;

--- a/frontend/src/app/post-card/post-card.component.html
+++ b/frontend/src/app/post-card/post-card.component.html
@@ -5,15 +5,27 @@
       <h3>{{ author }}</h3>
       <p>{{ timestamp }}</p>
     </div>
-    <button
-      *ngIf="canEdit"
-      type="button"
-      class="edit-btn"
-      aria-label="Edit your announcement"
-      (click)="onEditClick()"
-    >
-      Edit
-    </button>
+    <div class="owner-actions" *ngIf="canEdit || canDelete">
+      <button
+        *ngIf="canEdit"
+        type="button"
+        class="edit-btn"
+        aria-label="Edit your announcement"
+        (click)="onEditClick()"
+      >
+        Edit
+      </button>
+      <button
+        *ngIf="canDelete"
+        type="button"
+        class="delete-btn"
+        aria-label="Delete your announcement"
+        [disabled]="isDeleting"
+        (click)="onDeleteClick()"
+      >
+        {{ isDeleting ? 'Deleting...' : 'Delete' }}
+      </button>
+    </div>
     <span class="category-badge">{{ category }}</span>
   </header>
 

--- a/frontend/src/app/post-card/post-card.component.spec.ts
+++ b/frontend/src/app/post-card/post-card.component.spec.ts
@@ -45,4 +45,37 @@ describe('PostCardComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.post-image')).not.toBeNull();
   });
+
+  it('should render delete button when canDelete is true', () => {
+    const fixture = TestBed.createComponent(PostCardComponent);
+    fixture.componentRef.setInput('author', 'Test Author');
+    fixture.componentRef.setInput('timestamp', 'Now');
+    fixture.componentRef.setInput('category', 'General');
+    fixture.componentRef.setInput('content', 'Test content');
+    fixture.componentRef.setInput('canDelete', true);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.delete-btn')).not.toBeNull();
+  });
+
+  it('should emit deleteClicked when delete is clicked', () => {
+    const fixture = TestBed.createComponent(PostCardComponent);
+    fixture.componentRef.setInput('author', 'Test Author');
+    fixture.componentRef.setInput('timestamp', 'Now');
+    fixture.componentRef.setInput('category', 'General');
+    fixture.componentRef.setInput('content', 'Test content');
+    fixture.componentRef.setInput('canDelete', true);
+
+    let emitted = false;
+    fixture.componentInstance.deleteClicked.subscribe(() => {
+      emitted = true;
+    });
+    fixture.detectChanges();
+
+    const deleteButton = (fixture.nativeElement as HTMLElement).querySelector('.delete-btn') as HTMLButtonElement;
+    deleteButton.click();
+
+    expect(emitted).toBe(true);
+  });
 });

--- a/frontend/src/app/post-card/post-card.component.ts
+++ b/frontend/src/app/post-card/post-card.component.ts
@@ -19,7 +19,10 @@ export class PostCardComponent {
   @Input() likes = 0;
   @Input() comments = 0;
   @Input() canEdit = false;
+  @Input() canDelete = false;
+  @Input() isDeleting = false;
   @Output() editClicked = new EventEmitter<void>();
+  @Output() deleteClicked = new EventEmitter<void>();
 
   get authorInitials(): string {
     const names = this.author.trim().split(' ').filter(Boolean);
@@ -34,5 +37,9 @@ export class PostCardComponent {
 
   onEditClick(): void {
     this.editClicked.emit();
+  }
+
+  onDeleteClick(): void {
+    this.deleteClicked.emit();
   }
 }

--- a/frontend/src/app/services/announcement.service.spec.ts
+++ b/frontend/src/app/services/announcement.service.spec.ts
@@ -174,4 +174,32 @@ describe('AnnouncementService', () => {
       deleted_at: null
     });
   });
+
+  it('deletes announcement with bearer token', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-789');
+
+    let postedUrl = '';
+    let postedBody: unknown;
+    const postedHeaders: { Authorization?: string } = {};
+    const httpClientStub = {
+      get: () => of([]),
+      post: (url: string, body: unknown, options?: { headers?: { get(name: string): string | null } }) => {
+        postedUrl = url;
+        postedBody = body;
+        const auth = options?.headers?.get('Authorization');
+        if (auth) {
+          postedHeaders['Authorization'] = auth;
+        }
+        return of({ message: 'Announcement deleted successfully' });
+      }
+    } as unknown as HttpClient;
+
+    const service = new AnnouncementService(httpClientStub);
+    const response = await firstValueFrom(service.deleteAnnouncement({ id: 11 }));
+
+    expect(postedUrl).toBe('/api/announcements/delete');
+    expect(postedBody).toEqual({ id: 11 });
+    expect(postedHeaders['Authorization']).toBe('Bearer jwt-token-789');
+    expect(response.message).toBe('Announcement deleted successfully');
+  });
 });

--- a/frontend/src/app/services/announcement.service.ts
+++ b/frontend/src/app/services/announcement.service.ts
@@ -41,6 +41,14 @@ export interface UpdateAnnouncementPayload {
   content?: string;
 }
 
+export interface DeleteAnnouncementPayload {
+  id: number;
+}
+
+export interface DeleteAnnouncementResponse {
+  message: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -93,5 +101,16 @@ export class AnnouncementService {
     return this.http
       .post<RawAnnouncement>(`${this.apiUrl}/update`, payload, { headers })
       .pipe(map((raw) => this.normalizeAnnouncement(raw)));
+  }
+
+  deleteAnnouncement(payload: DeleteAnnouncementPayload): Observable<DeleteAnnouncementResponse> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http.post<DeleteAnnouncementResponse>(`${this.apiUrl}/delete`, payload, { headers });
   }
 }


### PR DESCRIPTION
## Summary
Implemented delete announcement functionality and integrated with backend API.

## Changes
- Added delete button for user’s announcements
- Implemented confirmation dialog before delete
- Connected to backend DELETE API
- Sent auth token with request
- Removed announcement from UI after successful delete

## Behavior
- Users can delete their own announcements
- Confirmation shown before deletion
- Announcement is removed from UI after delete
- Errors handled and displayed properly

## Preview

<img width="1242" height="840" alt="Screenshot 2026-03-24 at 5 58 39 PM" src="https://github.com/user-attachments/assets/e616c6b6-32d2-4a14-adcc-03fe16fed085" />

Closes #56