### PR TITLE
72 fe 17 implement account page and logout flow

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,10 +6,12 @@ import { LayoutComponent } from './layout/layout.component';
 import { SignupComponent } from './pages/signup/signup.component';
 import { LoginComponent } from './pages/login/login.component';
 import { authGuard } from './guards/auth.guard';
+import { AccountComponent } from './pages/account/account.component';
 
 export const routes: Routes = [
   { path: 'signup', component: SignupComponent },
   { path: 'login', component: LoginComponent },
+  { path: 'account', component: AccountComponent, canActivate: [authGuard] },
   {
     path: '',
     component: LayoutComponent,

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -28,7 +28,7 @@ export class NavbarComponent {
   }
 
   onAccountClick() {
-    void this.router.navigate(['/login']);
+    void this.router.navigate(['/account']);
   }
 
 }

--- a/frontend/src/app/navbar/navbar.spec.ts
+++ b/frontend/src/app/navbar/navbar.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
+import { vi } from 'vitest';
 import { NavbarComponent } from './navbar.component';
 
 describe('NavbarComponent', () => {
@@ -19,5 +20,14 @@ describe('NavbarComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to account page when account button is clicked', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.onAccountClick();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/account']);
   });
 });

--- a/frontend/src/app/pages/account/account.component.css
+++ b/frontend/src/app/pages/account/account.component.css
@@ -1,0 +1,206 @@
+.account-page {
+  min-height: 100vh;
+  background: #eceef2;
+}
+
+.account-topbar {
+  height: 64px;
+  padding: 0 2rem;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #d9dce1;
+  background: #ffffff;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  text-decoration: none;
+}
+
+.brand-badge {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #0b8b3d;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.brand-text {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #04753a;
+  line-height: 1;
+}
+
+.account-main {
+  min-height: calc(100vh - 64px);
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.account-shell {
+  width: min(100%, 640px);
+}
+
+.account-shell h1 {
+  margin: 0;
+  color: #101828;
+  font-size: 2.2rem;
+  line-height: 1.15;
+}
+
+.subheading {
+  margin: 0.4rem 0 1.5rem;
+  color: #475467;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #d6dae0;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.profile-card {
+  padding: 1.4rem;
+  display: flex;
+  gap: 1.2rem;
+}
+
+.avatar {
+  flex-shrink: 0;
+  width: 5.2rem;
+  height: 5.2rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #d1fae5;
+  border: 2px solid #a7f3d0;
+  color: #067647;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.profile-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-content h2 {
+  margin: 0 0 0.9rem;
+  color: #101828;
+  font-size: 2rem;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: 1.4rem 1fr;
+  align-items: start;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.field-grid:last-child {
+  margin-bottom: 0;
+}
+
+.field-icon {
+  color: #98a2b3;
+  font-size: 1.2rem;
+  margin-top: 0.18rem;
+}
+
+.field-label {
+  margin: 0;
+  color: #667085;
+}
+
+.field-value {
+  margin: 0.15rem 0 0;
+  color: #101828;
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.logout-card {
+  margin-top: 1.1rem;
+  padding: 1.25rem 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.logout-card h2 {
+  margin: 0;
+  color: #101828;
+  font-size: 1.9rem;
+}
+
+.logout-card p {
+  margin: 0.45rem 0 0;
+  color: #475467;
+}
+
+.logout-btn {
+  flex-shrink: 0;
+  height: 2.4rem;
+  padding: 0 1rem;
+  border-radius: 10px;
+  border: 1px solid #fda29b;
+  color: #d92d20;
+  background: #fff5f5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.logout-btn .material-icons {
+  font-size: 1rem;
+}
+
+.logout-btn:hover {
+  background: #ffe9e8;
+}
+
+@media (max-width: 768px) {
+  .account-topbar {
+    padding: 0 1rem;
+  }
+
+  .brand-text {
+    font-size: 1.5rem;
+  }
+
+  .account-shell h1 {
+    font-size: 1.7rem;
+  }
+
+  .profile-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile-content h2,
+  .logout-card h2 {
+    font-size: 1.4rem;
+  }
+
+  .field-value {
+    font-size: 1.05rem;
+  }
+
+  .logout-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/pages/account/account.component.css
+++ b/frontend/src/app/pages/account/account.component.css
@@ -101,9 +101,13 @@
 .field-grid {
   display: grid;
   grid-template-columns: 1.4rem 1fr;
-  align-items: start;
+  align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.85rem;
+  margin-bottom: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid #d6dae0;
+  border-radius: 10px;
+  background: #f9fafb;
 }
 
 .field-grid:last-child {
@@ -113,7 +117,6 @@
 .field-icon {
   color: #98a2b3;
   font-size: 1.2rem;
-  margin-top: 0.18rem;
 }
 
 .field-label {
@@ -126,6 +129,11 @@
   color: #101828;
   font-size: 1.2rem;
   font-weight: 500;
+}
+
+.field-value.field-placeholder {
+  color: #98a2b3;
+  font-weight: 400;
 }
 
 .logout-card {

--- a/frontend/src/app/pages/account/account.component.html
+++ b/frontend/src/app/pages/account/account.component.html
@@ -1,0 +1,59 @@
+<div class="account-page">
+  <header class="account-topbar">
+    <a class="brand" routerLink="/">
+      <span class="brand-badge" aria-hidden="true">N</span>
+      <span class="brand-text">Neighborhood</span>
+    </a>
+  </header>
+
+  <main class="account-main">
+    <section class="account-shell" aria-labelledby="account-title">
+      <h1 id="account-title">Account Settings</h1>
+      <p class="subheading">Manage your account details and preferences</p>
+
+      <section class="card profile-card">
+        <div class="avatar" aria-label="User initials">{{ initials }}</div>
+
+        <div class="profile-content">
+          <h2>Profile Information</h2>
+
+          <div class="field-grid">
+            <span class="material-icons field-icon" aria-hidden="true">person</span>
+            <div>
+              <p class="field-label">Name</p>
+              <p class="field-value">{{ displayName }}</p>
+            </div>
+          </div>
+
+          <div class="field-grid">
+            <span class="material-icons field-icon" aria-hidden="true">mail</span>
+            <div>
+              <p class="field-label">Email</p>
+              <p class="field-value">{{ displayEmail }}</p>
+            </div>
+          </div>
+
+          <div class="field-grid" *ngIf="displayBio">
+            <span class="material-icons field-icon" aria-hidden="true">description</span>
+            <div>
+              <p class="field-label">Bio</p>
+              <p class="field-value">{{ displayBio }}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card logout-card">
+        <div>
+          <h2>Sign out of your account</h2>
+          <p>You'll need to log back in to access your neighborhood</p>
+        </div>
+
+        <button type="button" class="logout-btn" (click)="onLogout()">
+          <span class="material-icons" aria-hidden="true">logout</span>
+          Log out
+        </button>
+      </section>
+    </section>
+  </main>
+</div>

--- a/frontend/src/app/pages/account/account.component.html
+++ b/frontend/src/app/pages/account/account.component.html
@@ -33,11 +33,11 @@
             </div>
           </div>
 
-          <div class="field-grid" *ngIf="displayBio">
+          <div class="field-grid">
             <span class="material-icons field-icon" aria-hidden="true">description</span>
             <div>
               <p class="field-label">Bio</p>
-              <p class="field-value">{{ displayBio }}</p>
+              <p class="field-value" [class.field-placeholder]="!hasBio">{{ displayBio }}</p>
             </div>
           </div>
         </div>

--- a/frontend/src/app/pages/account/account.component.spec.ts
+++ b/frontend/src/app/pages/account/account.component.spec.ts
@@ -54,7 +54,7 @@ describe('AccountComponent', () => {
     expect(compiled.textContent).toContain('Community member since 2024.');
   });
 
-  it('should hide bio row when bio is missing', () => {
+  it('should show placeholder bio when bio is missing', () => {
     authServiceStub.getStoredUser = () => ({
       id: 1,
       name: 'John Doe',
@@ -66,7 +66,8 @@ describe('AccountComponent', () => {
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.textContent).not.toContain('Bio');
+    expect(compiled.textContent).toContain('Bio');
+    expect(compiled.textContent).toContain('Tell us something about yourself!');
   });
 
   it('should clear auth session and navigate to login on logout', async () => {

--- a/frontend/src/app/pages/account/account.component.spec.ts
+++ b/frontend/src/app/pages/account/account.component.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { vi } from 'vitest';
+import { AccountComponent } from './account.component';
+import { AuthService, LoginUser } from '../../services/auth.service';
+
+describe('AccountComponent', () => {
+  const authServiceStub: {
+    getStoredUser: () => LoginUser | null;
+    clearAuthSession: () => void;
+  } = {
+    getStoredUser: () => ({
+      id: 1,
+      name: 'John Doe',
+      email: 'john@example.com',
+      bio: 'Community member since 2024.',
+      created_at: '2026-03-01T12:00:00Z'
+    }),
+    clearAuthSession: () => undefined
+  };
+
+  beforeEach(async () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'John Doe',
+      email: 'john@example.com',
+      bio: 'Community member since 2024.',
+      created_at: '2026-03-01T12:00:00Z'
+    });
+    authServiceStub.clearAuthSession = () => undefined;
+
+    await TestBed.configureTestingModule({
+      imports: [AccountComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: authServiceStub
+        }
+      ]
+    }).compileComponents();
+  });
+
+  it('should render user details and initials from stored user', () => {
+    const fixture = TestBed.createComponent(AccountComponent);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance;
+    expect(component.initials).toBe('JD');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('John Doe');
+    expect(compiled.textContent).toContain('john@example.com');
+    expect(compiled.textContent).toContain('Community member since 2024.');
+  });
+
+  it('should hide bio row when bio is missing', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'John Doe',
+      email: 'john@example.com',
+      created_at: '2026-03-01T12:00:00Z'
+    });
+
+    const fixture = TestBed.createComponent(AccountComponent);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).not.toContain('Bio');
+  });
+
+  it('should clear auth session and navigate to login on logout', async () => {
+    const fixture = TestBed.createComponent(AccountComponent);
+    const component = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+
+    const clearSpy = vi.spyOn(authServiceStub, 'clearAuthSession').mockImplementation(() => undefined);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.onLogout();
+
+    expect(clearSpy).toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/frontend/src/app/pages/account/account.component.ts
+++ b/frontend/src/app/pages/account/account.component.ts
@@ -13,6 +13,7 @@ import { AuthService, LoginUser } from '../../services/auth.service';
 export class AccountComponent {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
+  private readonly bioPlaceholder = 'Tell us something about yourself!';
 
   readonly user: LoginUser | null = this.authService.getStoredUser();
 
@@ -34,8 +35,17 @@ export class AccountComponent {
     return 'Not provided';
   }
 
+  get hasBio(): boolean {
+    return !!this.user?.bio?.trim();
+  }
+
   get displayBio(): string {
-    return this.user?.bio?.trim() ?? '';
+    const bio = this.user?.bio?.trim();
+    if (bio) {
+      return bio;
+    }
+
+    return this.bioPlaceholder;
   }
 
   get initials(): string {

--- a/frontend/src/app/pages/account/account.component.ts
+++ b/frontend/src/app/pages/account/account.component.ts
@@ -1,0 +1,60 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService, LoginUser } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-account',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './account.component.html',
+  styleUrl: './account.component.css'
+})
+export class AccountComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  readonly user: LoginUser | null = this.authService.getStoredUser();
+
+  get displayName(): string {
+    const name = this.user?.name?.trim();
+    if (name) {
+      return name;
+    }
+
+    return 'Neighbor';
+  }
+
+  get displayEmail(): string {
+    const email = this.user?.email?.trim();
+    if (email) {
+      return email;
+    }
+
+    return 'Not provided';
+  }
+
+  get displayBio(): string {
+    return this.user?.bio?.trim() ?? '';
+  }
+
+  get initials(): string {
+    const tokens = this.displayName
+      .split(' ')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0);
+
+    if (tokens.length === 0) {
+      return 'N';
+    }
+
+    const first = tokens[0][0];
+    const second = tokens.length > 1 ? tokens[tokens.length - 1][0] : '';
+    return `${first}${second}`.toUpperCase();
+  }
+
+  onLogout(): void {
+    this.authService.clearAuthSession();
+    void this.router.navigate(['/login']);
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -29,6 +29,7 @@ export interface LoginUser {
   id: number;
   name: string;
   email: string;
+  bio?: string;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
Implemented account page and logout flow with authentication handling.

## Changes
- Added account page UI
- Connected "Account" button to account page route
- Displayed user details (name, email, bio)
- Added profile picture placeholder with user initials
- Implemented logout functionality
- Cleared auth token on logout
- Redirected user to login page after logout
- Restricted access to protected routes without authentication

## Behavior
- Users can view their account details
- Bio field is optional
- Profile picture shows user initials by default
- Logout clears session and redirects to login
- Users cannot access home page after logout without logging in again

## Preview

<img width="1407" height="868" alt="Screenshot 2026-03-24 at 7 08 14 PM" src="https://github.com/user-attachments/assets/83d06744-14e1-49dd-8e2d-ec848bcbcda2" />


Closes #72