### PR TITLE
FE 21 - Add empty states for events

### DIFF
--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -327,3 +327,25 @@
     flex: 1;
   }
 }
+
+.empty-state {
+  background: #ffffff;
+  border: 1px dashed #d1d5db;
+  border-radius: 16px;
+  padding: 40px 24px;
+  text-align: center;
+  max-width: 500px;
+  margin: 40px auto 0;
+}
+
+.empty-state h3 {
+  margin-bottom: 8px;
+  font-size: 20px;
+  color: #111827;
+}
+
+.empty-state p {
+  color: #6b7280;
+  margin-bottom: 20px;
+  font-size: 14px;
+}

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -15,9 +15,9 @@
       </button>
 
       <span class="your-events"
-            (click)="showOnlyUserEvents = !showOnlyUserEvents">
-    {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
-  </span>
+                (click)="showOnlyUserEvents = !showOnlyUserEvents">
+        {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
+      </span>
     </div>
   </div>
 

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -7,17 +7,17 @@
     </div>
 
     <div class="header-actions">
-      <button class="create-event-btn" (click)="openCreateEvent()">
+      <button
+        class="create-event-btn"
+        *ngIf="displayedEvents.length > 0"
+        (click)="openCreateEvent()">
         Create an event
       </button>
+
       <span class="your-events"
             (click)="showOnlyUserEvents = !showOnlyUserEvents">
-        {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
-      </span>
-      <!--<p *ngIf="showOnlyUserEvents && displayedEvents.length === 0">
-        You haven't created any events yet.
-      </p>-->
-
+    {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
+  </span>
     </div>
   </div>
 

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -14,9 +14,9 @@
             (click)="showOnlyUserEvents = !showOnlyUserEvents">
         {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
       </span>
-      <p *ngIf="showOnlyUserEvents && displayedEvents.length === 0">
+      <!--<p *ngIf="showOnlyUserEvents && displayedEvents.length === 0">
         You haven't created any events yet.
-      </p>
+      </p>-->
 
     </div>
   </div>
@@ -91,7 +91,7 @@
   </div>
 
   <!-- EVENTS GRID -->
-  <div class="events-grid">
+  <!--<div class="events-grid">
   <div class="event-card" *ngFor="let event of displayedEvents">
 
       <div class="image-wrapper">
@@ -116,7 +116,7 @@
 
     </div>
 
-    <!-- Host Event Placeholder Card -->
+    &lt;!&ndash; Host Event Placeholder Card &ndash;&gt;
     <div class="event-card host-card" (click)="openCreateEvent()">
       <div class="host-content">
         <div class="plus-icon">+</div>
@@ -125,6 +125,67 @@
       </div>
     </div>
 
+  </div>-->
+
+  <!-- EVENTS GRID WITH EMPTY STATE -->
+  <div *ngIf="displayedEvents.length > 0; else emptyState">
+
+    <div class="events-grid">
+
+      <div class="event-card" *ngFor="let event of displayedEvents">
+
+        <div class="image-wrapper">
+          <img [src]="event.imageUrl" [alt]="event.name">
+
+          <div class="date-badge">
+            <span class="day">{{ event.date }}</span>
+            <span class="month">{{ event.month }}</span>
+          </div>
+
+          <div class="share-icon">⤴</div>
+        </div>
+
+        <div class="event-content">
+          <h3>{{ event.name }}</h3>
+          <p class="time">{{ event.time }}</p>
+          <p class="location">{{ event.location }}</p>
+          <p class="interested">{{ event.interested }} neighbors interested</p>
+
+          <button class="interest-btn">+ Interested?</button>
+        </div>
+
+      </div>
+
+      <!-- Host Event Card -->
+      <div class="event-card host-card" (click)="openCreateEvent()">
+        <div class="host-content">
+          <div class="plus-icon">+</div>
+          <h3>Host an event</h3>
+          <p>Bring your neighbors together for something fun!</p>
+        </div>
+      </div>
+
+    </div>
+
   </div>
+
+  <!-- EMPTY STATE -->
+  <ng-template #emptyState>
+    <div class="empty-state">
+      <h3>
+        {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
+      </h3>
+
+      <p>
+        {{ showOnlyUserEvents
+        ? "You haven't created any events yet. Start by creating one."
+        : "There are no events to display right now." }}
+      </p>
+
+      <button class="create-event-btn" (click)="openCreateEvent()">
+        Create an event
+      </button>
+    </div>
+  </ng-template>
 
 </section>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -110,7 +110,7 @@ export class EventsComponent {
 
 
   events: EventItem[] = [
-    /* {
+     {
       id: 1,
       name: 'Block Party & BBQ',
       date: '19',
@@ -149,7 +149,7 @@ export class EventsComponent {
       location: 'Town Center',
       interested: 124,
       imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?auto=format&fit=crop&w=1200&q=80'
-    } */
+    }
   ];
 
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -110,7 +110,7 @@ export class EventsComponent {
 
 
   events: EventItem[] = [
-    {
+    /* {
       id: 1,
       name: 'Block Party & BBQ',
       date: '19',
@@ -149,7 +149,7 @@ export class EventsComponent {
       location: 'Town Center',
       interested: 124,
       imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?auto=format&fit=crop&w=1200&q=80'
-    }
+    } */
   ];
 
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -93,6 +93,7 @@ export class EventsComponent {
       interested: 0,
       imageUrl: 'https://images.unsplash.com/photo-1523580494863-6f3031224c94'
     };
+    this.imagePreview = null;
   }
 
   get displayedEvents(): EventItem[] {


### PR DESCRIPTION
Implemented empty state UI for the Events page to improve user experience when no events are available or when the user has not created any events.

Added conditional rendering to display a centered empty-state card with contextual messaging and a clear call-to-action to create a new event. Also updated the header to hide the duplicate “Create an event” button when the event list is empty to avoid redundancy.

Changes Made
* Added empty state UI using *ngIf and ng-template
* Handled two cases:
* No events available
* No user-created events (“Your Events” view)
* Added “Create an event” CTA inside empty state
* Hid header “Create an event” button when events list is empty
* Removed old inline empty message logic
* Added styling for empty state component

<img width="1704" height="997" alt="Screenshot 2026-04-11 at 1 03 50 PM" src="https://github.com/user-attachments/assets/37f0f729-d065-4b94-9cce-e4706b1b6179" />
<img width="1703" height="1008" alt="Screenshot 2026-04-11 at 1 04 54 PM" src="https://github.com/user-attachments/assets/dd447889-99b0-4e5b-a519-539d2ccc402a" />
