### PR TITLE
Home navigation button added on account page

### DIFF
--- a/frontend/src/app/pages/account/account.component.css
+++ b/frontend/src/app/pages/account/account.component.css
@@ -48,11 +48,42 @@
   width: min(100%, 640px);
 }
 
+.heading-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.55rem;
+}
+
 .account-shell h1 {
   margin: 0;
   color: #101828;
   font-size: 2.2rem;
   line-height: 1.15;
+}
+
+.home-btn {
+  flex-shrink: 0;
+  height: 2.4rem;
+  padding: 0 0.95rem;
+  border-radius: 10px;
+  border: 1px solid #a7f3d0;
+  background: #e7f8ee;
+  color: #067647;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.home-btn .material-icons {
+  font-size: 1rem;
+}
+
+.home-btn:hover {
+  background: #d8f2e3;
 }
 
 .subheading {

--- a/frontend/src/app/pages/account/account.component.html
+++ b/frontend/src/app/pages/account/account.component.html
@@ -8,7 +8,15 @@
 
   <main class="account-main">
     <section class="account-shell" aria-labelledby="account-title">
-      <h1 id="account-title">Account Settings</h1>
+      <div class="heading-row">
+        <button type="button" class="home-btn" (click)="onBackToHome()">
+          <span class="material-icons" aria-hidden="true">west</span>
+          Back to Home
+        </button>
+
+        <h1 id="account-title">Account Settings</h1>
+      </div>
+
       <p class="subheading">Manage your account details and preferences</p>
 
       <section class="card profile-card">

--- a/frontend/src/app/pages/account/account.component.spec.ts
+++ b/frontend/src/app/pages/account/account.component.spec.ts
@@ -70,6 +70,23 @@ describe('AccountComponent', () => {
     expect(compiled.textContent).toContain('Tell us something about yourself!');
   });
 
+  it('should render back to home button and navigate home on click', () => {
+    const fixture = TestBed.createComponent(AccountComponent);
+    fixture.detectChanges();
+
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const compiled = fixture.nativeElement as HTMLElement;
+    const homeButton = compiled.querySelector('.home-btn') as HTMLButtonElement;
+
+    expect(homeButton).not.toBeNull();
+    expect(homeButton.textContent).toContain('Back to Home');
+
+    homeButton.click();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/']);
+  });
+
   it('should clear auth session and navigate to login on logout', async () => {
     const fixture = TestBed.createComponent(AccountComponent);
     const component = fixture.componentInstance;

--- a/frontend/src/app/pages/account/account.component.ts
+++ b/frontend/src/app/pages/account/account.component.ts
@@ -67,4 +67,8 @@ export class AccountComponent {
     this.authService.clearAuthSession();
     void this.router.navigate(['/login']);
   }
+
+  onBackToHome(): void {
+    void this.router.navigate(['/']);
+  }
 }


### PR DESCRIPTION
## Summary
Added a navigation button on the Account page to allow users to easily return to the home page.

## Changes

- Added "Back to Home" button on Account page
- Implemented routing to `/home` (or `/`) on click
- Positioned button near header for clear visibility
- Applied consistent styling with existing UI

## Behavior/Features

- Users can navigate back to the home page from the Account page
- Navigation occurs without page refresh
- Button is visible and accessible across screen sizes

## Preview

<img width="1511" height="900" alt="Screenshot 2026-04-11 at 8 27 33 PM" src="https://github.com/user-attachments/assets/731d926a-b776-4e75-bc04-78a0a7b11938" />


Closes #83 