### PR TITLE
90 fe 23 add frontend unit tests

### DIFF
--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -1,0 +1,28 @@
+import { routes } from './app.routes';
+import { authGuard } from './guards/auth.guard';
+import { AccountComponent } from './pages/account/account.component';
+import { NeighborhoodComponent } from './pages/neighborhood/neighborhood.component';
+
+describe('App Routes', () => {
+  it('should protect account route with auth guard', () => {
+    const accountRoute = routes.find((route) => route.path === 'account');
+
+    expect(accountRoute).toBeDefined();
+    expect(accountRoute?.component).toBe(AccountComponent);
+    expect(accountRoute?.canActivate).toContain(authGuard);
+  });
+
+  it('should include neighborhood page in authenticated child routes', () => {
+    const layoutRoute = routes.find((route) => route.path === '');
+    const neighborhoodRoute = layoutRoute?.children?.find((route) => route.path === 'neighborhood');
+
+    expect(neighborhoodRoute).toBeDefined();
+    expect(neighborhoodRoute?.component).toBe(NeighborhoodComponent);
+  });
+
+  it('should include wildcard redirect to root', () => {
+    const wildcardRoute = routes.find((route) => route.path === '**');
+
+    expect(wildcardRoute?.redirectTo).toBe('');
+  });
+});

--- a/frontend/src/app/navbar/navbar.spec.ts
+++ b/frontend/src/app/navbar/navbar.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { vi } from 'vitest';
 import { NavbarComponent } from './navbar.component';
+import { SearchService } from '../services/search.service';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -29,5 +30,18 @@ describe('NavbarComponent', () => {
     component.onAccountClick();
 
     expect(navigateSpy).toHaveBeenCalledWith(['/account']);
+  });
+
+  it('should submit search query without page reload', () => {
+    const searchService = TestBed.inject(SearchService);
+    const setSearchSpy = vi.spyOn(searchService, 'setSearchQuery');
+    const preventDefault = vi.fn();
+    component.searchQuery = 'road repairs';
+
+    component.onSearchSubmit({ preventDefault } as unknown as Event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(setSearchSpy).toHaveBeenCalledWith('road repairs');
+    expect(searchService.searchQuery()).toBe('road repairs');
   });
 });

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
 
 describe('EventsComponent', () => {
@@ -12,10 +13,161 @@ describe('EventsComponent', () => {
 
     fixture = TestBed.createComponent(EventsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show no-events empty state by default', () => {
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const emptyState = compiled.querySelector('.empty-state');
+
+    expect(emptyState).not.toBeNull();
+    expect(emptyState?.textContent).toContain('No events available');
+  });
+
+  it('should show empty state when viewing only user events and none exist', () => {
+    component.showOnlyUserEvents = true;
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const emptyState = compiled.querySelector('.empty-state');
+
+    expect(emptyState).not.toBeNull();
+    expect(emptyState?.textContent).toContain('No events created yet');
+    expect(compiled.querySelector('.header-actions .create-event-btn')).toBeNull();
+  });
+
+  it('should open create event modal from empty state action', () => {
+    component.showOnlyUserEvents = true;
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const emptyStateCreateButton = compiled.querySelector('.empty-state .create-event-btn') as HTMLButtonElement;
+
+    emptyStateCreateButton.click();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    expect(component.showCreateEventForm).toBe(true);
+    expect(compiled.querySelector('.event-modal-overlay')).not.toBeNull();
+  });
+
+  it('should keep form invalid when required fields are empty', () => {
+    component.openCreateEvent();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const form = compiled.querySelector('form') as HTMLFormElement;
+
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it('should create a user event and reset the form state', () => {
+    const initialEventCount = component.events.length;
+    component.newEvent = {
+      name: 'Neighborhood Cleanup',
+      date: '30',
+      month: 'APR',
+      time: '10:00 AM',
+      location: 'Depot Park',
+      interested: 0,
+      imageUrl: ''
+    };
+    const mockForm = {
+      invalid: false,
+      control: { markAllAsTouched: () => undefined },
+      resetForm: () => undefined
+    };
+
+    component.createEvent(mockForm as never);
+
+    expect(component.events.length).toBe(initialEventCount + 1);
+    expect(component.events[0].createdByUser).toBe(true);
+    expect(component.showCreateEventForm).toBe(false);
+    expect(component.newEvent.name).toBe('');
+  });
+
+  it('should show delete button only for user-created events', () => {
+    component.events = [
+      {
+        id: 1001,
+        name: 'User Event',
+        date: '15',
+        month: 'APR',
+        time: '5:00 PM',
+        location: 'UF Campus',
+        interested: 10,
+        imageUrl: 'https://example.com/user-event.jpg',
+        createdByUser: true
+      },
+      {
+        id: 1002,
+        name: 'Community Event',
+        date: '16',
+        month: 'APR',
+        time: '6:00 PM',
+        location: 'Downtown',
+        interested: 20,
+        imageUrl: 'https://example.com/community-event.jpg',
+        createdByUser: false
+      }
+    ];
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const deleteButtons = compiled.querySelectorAll('.delete-btn');
+
+    expect(deleteButtons.length).toBe(1);
+  });
+
+  it('should delete event when user confirms', () => {
+    component.events = [
+      {
+        id: 2001,
+        name: 'To Delete',
+        date: '20',
+        month: 'APR',
+        time: '7:00 PM',
+        location: 'Depot Park',
+        interested: 5,
+        imageUrl: 'https://example.com/delete.jpg',
+        createdByUser: true
+      }
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    component.deleteEvent(2001);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(component.events.length).toBe(0);
+    confirmSpy.mockRestore();
+  });
+
+  it('should keep event when user cancels delete confirmation', () => {
+    component.events = [
+      {
+        id: 3001,
+        name: 'Keep Event',
+        date: '21',
+        month: 'APR',
+        time: '7:30 PM',
+        location: 'Bo Diddley Plaza',
+        interested: 9,
+        imageUrl: 'https://example.com/keep.jpg',
+        createdByUser: true
+      }
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    component.deleteEvent(3001);
+
+    expect(component.events.length).toBe(1);
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/app/pages/neighborhood/neighborhood.spec.ts
+++ b/frontend/src/app/pages/neighborhood/neighborhood.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { NeighborhoodComponent } from './neighborhood.component';
 
 describe('NeighborhoodComponent', () => {
@@ -36,5 +37,35 @@ describe('NeighborhoodComponent', () => {
     expect(compiled.textContent).toContain('Restaurants');
     expect(compiled.textContent).toContain('Shopping');
     expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should switch visible items when category changes', () => {
+    const fixture = TestBed.createComponent(NeighborhoodComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.selectedCategory).toBe('Landmarks');
+
+    component.selectCategory('Restaurants');
+
+    expect(component.selectedCategory).toBe('Restaurants');
+    expect(component.visibleItems.some((item) => item.name.includes('Sushi'))).toBe(true);
+  });
+
+  it('should focus a selected item on the map when marker exists', () => {
+    const fixture = TestBed.createComponent(NeighborhoodComponent);
+    const component = fixture.componentInstance as any;
+    const restaurant = component.categoryData.Restaurants[0];
+    const flyToSpy = vi.fn();
+    const removeSpy = vi.fn();
+    const openPopupSpy = vi.fn();
+
+    component.map = { flyTo: flyToSpy, remove: removeSpy };
+    component.categoryMarkers.set(restaurant.name, { openPopup: openPopupSpy });
+
+    component.focusItem(restaurant);
+
+    expect(component.activeItemName).toBe(restaurant.name);
+    expect(flyToSpy).toHaveBeenCalled();
+    expect(openPopupSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Added additional Angular unit tests to improve frontend test coverage for key features and flows.

## Changes

- Added unit tests for Neighborhood page
- Added tests for Events (empty states, form validation, deletion flow)
- Added tests for Account page home navigation flow
- Improved coverage for navbar and routing behavior

## Behavior

- Core frontend features are now covered with unit tests
- Edge cases (empty states, validation, deletion) are tested
- All tests run successfully without errors

Closes #90 