### PR TITLE
Events GET api integrated with frontend

### DIFF
--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -46,6 +46,36 @@
   gap: 24px;
 }
 
+.events-empty-note {
+  margin: 0 0 14px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.status-state {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  max-width: 500px;
+  margin: 24px auto 0;
+}
+
+.loading-state {
+  color: #374151;
+}
+
+.error-state {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.error-state p {
+  color: #b91c1c;
+  margin: 0 0 14px 0;
+}
+
 .event-card {
   background: #ffffff;
   border-radius: 16px;

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -172,8 +172,16 @@
 
   </div>-->
 
-  <!-- EVENTS GRID WITH EMPTY STATE -->
-  <div *ngIf="displayedEvents.length > 0; else emptyState">
+  <div *ngIf="eventsError" class="status-state error-state">
+    <p>{{ eventsError }}</p>
+    <button type="button" class="create-event-btn" (click)="fetchEvents()">Retry</button>
+  </div>
+
+  <!-- EVENTS GRID -->
+  <div *ngIf="!eventsError">
+    <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
+      {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
+    </div>
 
     <div class="events-grid">
 
@@ -221,26 +229,6 @@
       </div>
 
     </div>
-
   </div>
-
-  <!-- EMPTY STATE -->
-  <ng-template #emptyState>
-    <div class="empty-state">
-      <h3>
-        {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
-      </h3>
-
-      <p>
-        {{ showOnlyUserEvents
-        ? "You haven't created any events yet. Start by creating one."
-        : "There are no events to display right now." }}
-      </p>
-
-      <button class="create-event-btn" (click)="openCreateEvent()">
-        Create an event
-      </button>
-    </div>
-  </ng-template>
 
 </section>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,8 +1,9 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
-import { finalize } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { finalize, Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { CommunityEvent, EventService } from '../../services/event.service';
 
@@ -26,7 +27,7 @@ interface EventItem {
   templateUrl: './events.component.html',
   styleUrl: './events.component.css'
 })
-export class EventsComponent implements OnInit {
+export class EventsComponent implements OnInit, OnDestroy {
   showCreateEventForm = false;
   showOnlyUserEvents = false;
   isLoadingEvents = false;
@@ -35,16 +36,24 @@ export class EventsComponent implements OnInit {
   imagePreview: string | null = null;
   imageError = '';
   private currentUserId = '';
+  private routeSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
 
   constructor(
+    private readonly route: ActivatedRoute,
     private readonly eventService: EventService,
     private readonly authService: AuthService
   ) {}
 
   ngOnInit(): void {
     this.loadCurrentUserContext();
-    this.fetchEvents();
+    this.routeSubscription = this.route.queryParamMap.subscribe(() => {
+      this.fetchEvents();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
   }
 
   newEvent = {

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,6 +1,10 @@
-import { Component } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
+import { finalize } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+import { CommunityEvent, EventService } from '../../services/event.service';
 
 interface EventItem {
   id: number;
@@ -11,6 +15,7 @@ interface EventItem {
   location: string;
   interested: number;
   imageUrl: string;
+  author?: string;
   createdByUser?: boolean;
 }
 
@@ -21,12 +26,26 @@ interface EventItem {
   templateUrl: './events.component.html',
   styleUrl: './events.component.css'
 })
-export class EventsComponent {
+export class EventsComponent implements OnInit {
   showCreateEventForm = false;
   showOnlyUserEvents = false;
+  isLoadingEvents = false;
+  eventsError = '';
 
   imagePreview: string | null = null;
   imageError = '';
+  private currentUserId = '';
+  private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+  constructor(
+    private readonly eventService: EventService,
+    private readonly authService: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadCurrentUserContext();
+    this.fetchEvents();
+  }
 
   newEvent = {
     name: '',
@@ -47,56 +66,29 @@ export class EventsComponent {
 
     this.events = this.events.filter(event => event.id !== id);
   }
+  events: EventItem[] = [];
 
+  fetchEvents(): void {
+    this.isLoadingEvents = true;
+    this.eventsError = '';
 
-
-
-
-  events: EventItem[] = [
-    /* {
-      id: 1,
-      name: 'Block Party & BBQ',
-      date: '19',
-      month: 'FEB',
-      time: '9:15 AM',
-      location: 'Willow Creek Park',
-      interested: 45,
-      imageUrl:
-        'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 2,
-      name: 'Morning Yoga in the Park',
-      date: '20',
-      month: 'FEB',
-      time: '11:00 AM',
-      location: 'Community Center',
-      interested: 12,
-      imageUrl:
-        'https://images.unsplash.com/photo-1552196563-55cd4e45efb3?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 3,
-      name: 'Local Book Club Meeting',
-      date: '22',
-      month: 'FEB',
-      time: '6:30 PM',
-      location: 'Public Library',
-      interested: 8,
-      imageUrl:
-        'https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 4,
-      name: 'Saturday Farmers Market',
-      date: '24',
-      month: 'FEB',
-      time: '8:00 AM',
-      location: 'Town Center',
-      interested: 124,
-      imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?auto=format&fit=crop&w=1200&q=80'
-    } */
-  ];
+    this.eventService
+      .getEvents()
+      .pipe(finalize(() => {
+        this.isLoadingEvents = false;
+      }))
+      .subscribe({
+        next: (events) => {
+          this.events = events
+            .filter((event) => this.isUpcomingEvent(event.date))
+            .map((event) => this.mapToEventItem(event));
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.eventsError = this.getFetchErrorMessage(error);
+        }
+      });
+  }
 
   get displayedEvents(): EventItem[] {
     if (this.showOnlyUserEvents) {
@@ -176,5 +168,93 @@ export class EventsComponent {
     };
     this.imagePreview = null;
     this.imageError = '';
+  }
+
+  private mapToEventItem(event: CommunityEvent): EventItem {
+    const badge = this.getDateBadge(event.date);
+    return {
+      id: event.id,
+      name: event.title,
+      date: badge.day,
+      month: badge.month,
+      time: event.time,
+      location: event.location,
+      interested: 0,
+      imageUrl: event.image_url,
+      author: event.author,
+      createdByUser: this.currentUserId !== '' && event.author === this.currentUserId
+    };
+  }
+
+  private getDateBadge(dateValue: string): { day: string; month: string } {
+    const trimmed = dateValue.trim();
+    if (!trimmed) {
+      return { day: '', month: '' };
+    }
+
+    const isoDateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoDateMatch) {
+      const monthIndex = Number(isoDateMatch[2]) - 1;
+      return {
+        day: String(Number(isoDateMatch[3])).padStart(2, '0'),
+        month: this.monthLabels[monthIndex] ?? ''
+      };
+    }
+
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        day: String(parsed.getDate()).padStart(2, '0'),
+        month: this.monthLabels[parsed.getMonth()] ?? ''
+      };
+    }
+
+    return { day: trimmed, month: '' };
+  }
+
+  private isUpcomingEvent(dateValue: string): boolean {
+    const trimmed = dateValue.trim();
+    if (!trimmed) {
+      return true;
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      return true;
+    }
+
+    const eventDay = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
+    const today = new Date();
+    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+
+    return eventDay >= todayStart;
+  }
+
+  private loadCurrentUserContext(): void {
+    const user = this.authService.getStoredUser();
+    this.currentUserId = user ? `${user.id}` : '';
+  }
+
+  private getFetchErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to load events.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to load events.';
   }
 }

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -1,14 +1,41 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
+import { AuthService } from '../../services/auth.service';
+import { CommunityEvent, EventService } from '../../services/event.service';
 
 describe('EventsComponent', () => {
   let component: EventsComponent;
   let fixture: ComponentFixture<EventsComponent>;
+  const eventServiceStub: {
+    getEvents: () => Observable<CommunityEvent[]>;
+  } = {
+    getEvents: () => of([])
+  };
+  const authServiceStub: {
+    getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
+  } = {
+    getStoredUser: () => null
+  };
 
   beforeEach(async () => {
+    eventServiceStub.getEvents = () => of([]);
+    authServiceStub.getStoredUser = () => null;
+
     await TestBed.configureTestingModule({
-      imports: [EventsComponent]
+      imports: [EventsComponent],
+      providers: [
+        {
+          provide: EventService,
+          useValue: eventServiceStub
+        },
+        {
+          provide: AuthService,
+          useValue: authServiceStub
+        }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(EventsComponent);
@@ -19,41 +46,168 @@ describe('EventsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show no-events empty state by default', () => {
+  it('should fetch and map backend events to UI fields on init', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 7,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1,
+          title: 'Community BBQ',
+          date: '2099-04-20',
+          time: '5:00 PM',
+          location: 'Central Park Pavilion',
+          image_url: '/uploads/1712345678_abc123.jpg',
+          author: '7',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    expect(component.events.length).toBe(1);
+    expect(component.events[0].name).toBe('Community BBQ');
+    expect(component.events[0].date).toBe('20');
+    expect(component.events[0].month).toBe('APR');
+    expect(component.events[0].imageUrl).toBe('/uploads/1712345678_abc123.jpg');
+    expect(component.events[0].createdByUser).toBe(true);
+  });
+
+  it('should show error state when fetch fails', () => {
+    eventServiceStub.getEvents = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 0
+          })
+      );
+
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyState = compiled.querySelector('.empty-state');
+    const errorState = compiled.querySelector('.error-state');
 
-    expect(emptyState).not.toBeNull();
-    expect(emptyState?.textContent).toContain('No events available');
+    expect(errorState).not.toBeNull();
+    expect(component.eventsError).toBe('Unable to reach the backend. Make sure the API is running.');
   });
 
-  it('should show empty state when viewing only user events and none exist', () => {
+  it('should show only host card when there are no events', () => {
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const hostCard = compiled.querySelector('.host-card');
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
+
+    expect(hostCard).not.toBeNull();
+    expect(eventCards.length).toBe(0);
+    expect(emptyNote?.textContent).toContain('No events available');
+  });
+
+  it('should show \"No events created yet\" when filtering to your events with none present', () => {
     component.showOnlyUserEvents = true;
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyState = compiled.querySelector('.empty-state');
+    const hostCard = compiled.querySelector('.host-card');
+    const emptyNote = compiled.querySelector('.events-empty-note');
 
-    expect(emptyState).not.toBeNull();
-    expect(emptyState?.textContent).toContain('No events created yet');
-    expect(compiled.querySelector('.header-actions .create-event-btn')).toBeNull();
+    expect(hostCard).not.toBeNull();
+    expect(emptyNote?.textContent).toContain('No events created yet');
   });
 
-  it('should open create event modal from empty state action', () => {
+  it('should show fetched events and keep host card at the end', () => {
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 10,
+          title: 'Morning Yoga in the Park',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const hostCard = compiled.querySelector('.host-card');
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
+
+    expect(eventCards.length).toBe(1);
+    expect(hostCard).not.toBeNull();
+    expect(emptyNote).toBeNull();
+  });
+
+  it('should hide empty note when showing only user events that exist', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 3,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 10,
+          title: 'My Event',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
     component.showOnlyUserEvents = true;
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyStateCreateButton = compiled.querySelector('.empty-state .create-event-btn') as HTMLButtonElement;
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
 
-    emptyStateCreateButton.click();
-    fixture.detectChanges();
+    expect(eventCards.length).toBe(1);
+    expect(emptyNote).toBeNull();
+  });
+
+  it('should not render past events from the API', () => {
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 11,
+          title: 'Old Event',
+          date: '2000-01-01',
+          time: '8:00 AM',
+          location: 'Old Park',
+          image_url: '',
+          author: '2',
+          created_at: '2000-01-01T10:00:00Z'
+        },
+        {
+          id: 12,
+          title: 'Upcoming Event',
+          date: '2099-01-01',
+          time: '9:00 AM',
+          location: 'Future Park',
+          image_url: '',
+          author: '2',
+          created_at: '2098-12-01T10:00:00Z'
+        }
+      ]);
+
     fixture.detectChanges();
 
-    expect(component.showCreateEventForm).toBe(true);
-    expect(compiled.querySelector('.event-modal-overlay')).not.toBeNull();
+    expect(component.events.length).toBe(1);
+    expect(component.events[0].name).toBe('Upcoming Event');
   });
 
   it('should keep form invalid when required fields are empty', () => {
@@ -93,6 +247,7 @@ describe('EventsComponent', () => {
   });
 
   it('should show delete button only for user-created events', () => {
+    fixture.detectChanges();
     component.events = [
       {
         id: 1001,
@@ -117,7 +272,6 @@ describe('EventsComponent', () => {
         createdByUser: false
       }
     ];
-    fixture.detectChanges();
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Observable, of, throwError } from 'rxjs';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
 import { AuthService } from '../../services/auth.service';
@@ -9,6 +10,7 @@ import { CommunityEvent, EventService } from '../../services/event.service';
 describe('EventsComponent', () => {
   let component: EventsComponent;
   let fixture: ComponentFixture<EventsComponent>;
+  let routeQueryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
   } = {
@@ -23,10 +25,17 @@ describe('EventsComponent', () => {
   beforeEach(async () => {
     eventServiceStub.getEvents = () => of([]);
     authServiceStub.getStoredUser = () => null;
+    routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
     await TestBed.configureTestingModule({
       imports: [EventsComponent],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: routeQueryParamMap$.asObservable()
+          }
+        },
         {
           provide: EventService,
           useValue: eventServiceStub
@@ -75,6 +84,17 @@ describe('EventsComponent', () => {
     expect(component.events[0].month).toBe('APR');
     expect(component.events[0].imageUrl).toBe('/uploads/1712345678_abc123.jpg');
     expect(component.events[0].createdByUser).toBe(true);
+  });
+
+  it('should refetch events when events refresh query param changes', () => {
+    const getEventsSpy = vi.fn(() => of([]));
+    eventServiceStub.getEvents = getEventsSpy;
+
+    fixture.detectChanges();
+    expect(getEventsSpy).toHaveBeenCalledTimes(1);
+
+    routeQueryParamMap$.next(convertToParamMap({ refresh: '1' }));
+    expect(getEventsSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should show error state when fetch fails', () => {

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -1,0 +1,79 @@
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom, of } from 'rxjs';
+import { EventService } from './event.service';
+
+describe('EventService', () => {
+  it('normalizes snake_case event payload fields', async () => {
+    let requestedUrl = '';
+    const httpClientStub = {
+      get: (url: string) => {
+        requestedUrl = url;
+        return of([
+          {
+            id: 1,
+            title: ' Community BBQ ',
+            date: '2026-04-20',
+            time: '5:00 PM',
+            location: 'Central Park Pavilion',
+            image_url: '/uploads/example.jpg',
+            author: 7,
+            created_at: '2026-04-10T14:23:15Z'
+          }
+        ]);
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(requestedUrl).toBe('/api/events');
+    expect(events[0]).toEqual({
+      id: 1,
+      title: 'Community BBQ',
+      date: '2026-04-20',
+      time: '5:00 PM',
+      location: 'Central Park Pavilion',
+      image_url: '/uploads/example.jpg',
+      author: '7',
+      created_at: '2026-04-10T14:23:15Z',
+      updated_at: undefined,
+      deleted_at: null
+    });
+  });
+
+  it('normalizes PascalCase fields and fallback defaults', async () => {
+    const httpClientStub = {
+      get: () =>
+        of([
+          {
+            ID: 42,
+            Title: ' ',
+            Date: '2026-05-02',
+            Time: '9:00 AM',
+            Location: 'Depot Park',
+            ImageURL: '/uploads/depot.jpg',
+            Author: '9',
+            CreatedAt: '2026-05-01T13:30:00Z',
+            UpdatedAt: '2026-05-01T13:35:00Z',
+            DeletedAt: null
+          }
+        ])
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(events[0]).toEqual({
+      id: 42,
+      title: 'Community Event',
+      date: '2026-05-02',
+      time: '9:00 AM',
+      location: 'Depot Park',
+      image_url: '/uploads/depot.jpg',
+      author: '9',
+      created_at: '2026-05-01T13:30:00Z',
+      updated_at: '2026-05-01T13:35:00Z',
+      deleted_at: null
+    });
+  });
+});

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiConfig } from '../config/api.config';
+
+interface RawEvent {
+  id?: number;
+  ID?: number;
+  title?: string;
+  Title?: string;
+  date?: string;
+  Date?: string;
+  time?: string;
+  Time?: string;
+  location?: string;
+  Location?: string;
+  image_url?: string;
+  imageUrl?: string;
+  ImageURL?: string;
+  author?: string | number;
+  Author?: string | number;
+  created_at?: string;
+  CreatedAt?: string;
+  updated_at?: string;
+  UpdatedAt?: string;
+  deleted_at?: string | null;
+  DeletedAt?: string | null;
+}
+
+export interface CommunityEvent {
+  id: number;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  image_url: string;
+  author: string;
+  created_at: string;
+  updated_at?: string;
+  deleted_at?: string | null;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventService {
+  private readonly apiUrl = `${ApiConfig.baseUrl}/events`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  private normalizeEvent(raw: RawEvent): CommunityEvent {
+    return {
+      id: raw.id ?? raw.ID ?? 0,
+      title: (raw.title ?? raw.Title ?? '').trim() || 'Community Event',
+      date: raw.date ?? raw.Date ?? '',
+      time: raw.time ?? raw.Time ?? '',
+      location: raw.location ?? raw.Location ?? '',
+      image_url: raw.image_url ?? raw.imageUrl ?? raw.ImageURL ?? '',
+      author: String(raw.author ?? raw.Author ?? ''),
+      created_at: raw.created_at ?? raw.CreatedAt ?? '',
+      updated_at: raw.updated_at ?? raw.UpdatedAt,
+      deleted_at: raw.deleted_at ?? raw.DeletedAt ?? null
+    };
+  }
+
+  getEvents(): Observable<CommunityEvent[]> {
+    return this.http
+      .get<RawEvent[]>(this.apiUrl)
+      .pipe(map((events) => events.map((event) => this.normalizeEvent(event))));
+  }
+}

--- a/frontend/src/app/sidebar/sidebar.component.html
+++ b/frontend/src/app/sidebar/sidebar.component.html
@@ -22,6 +22,14 @@
 
     <a
             routerLink="/events"
+            [queryParams]="{ refresh: eventsRefreshToken }"
+            (click)="refreshEventsLink()"
+            [routerLinkActiveOptions]="{
+              paths: 'exact',
+              queryParams: 'ignored',
+              matrixParams: 'ignored',
+              fragment: 'ignored'
+            }"
             routerLinkActive="active"
             class="menu-item"
     >

--- a/frontend/src/app/sidebar/sidebar.component.ts
+++ b/frontend/src/app/sidebar/sidebar.component.ts
@@ -8,4 +8,10 @@ import { RouterModule } from '@angular/router';
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css'
 })
-export class SidebarComponent {}
+export class SidebarComponent {
+  eventsRefreshToken = 0;
+
+  refreshEventsLink(): void {
+    this.eventsRefreshToken += 1;
+  }
+}


### PR DESCRIPTION
## Summary
Integrated backend Events API to fetch and display real event data on the Events page.

## Changes

- Replaced mock/in-memory event data with backend API integration
- Implemented GET `/api/events` using `EventService`
- Mapped backend fields to frontend UI fields
- Added loading state while fetching events
- Added error handling for failed requests
- Preserved empty-state UI when no events are returned

## Behavior/Features

- Events are dynamically fetched from the backend
- Loading indicator is shown during API calls
- Errors are handled and displayed appropriately
- Empty state is shown when no events exist

## Preview

<img width="1203" height="743" alt="Screenshot 2026-04-27 at 4 12 58 PM" src="https://github.com/user-attachments/assets/e8da03b0-e34d-4cbe-a20e-ac798a7e2fa5" />

Closes #105 