### PR TITLE
Create event connected with backend POST api

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -18,6 +18,7 @@
           "builder": "@angular/build:application",
           "options": {
             "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "@types/leaflet": "^1.9.21",
         "leaflet": "^1.9.4",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "zone.js": "^0.16.1"
       },
       "devDependencies": {
         "@angular/build": "^21.1.3",
@@ -10499,6 +10500,12 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
+      "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,8 @@
     "@types/leaflet": "^1.9.21",
     "leaflet": "^1.9.4",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "zone.js": "^0.16.1"
   },
   "devDependencies": {
     "@angular/build": "^21.1.3",

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -4,5 +4,11 @@
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
+  },
+  "/uploads": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
   }
 }

--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -99,6 +99,12 @@
   object-fit: cover;
 }
 
+.image-placeholder {
+  width: 100%;
+  height: 100%;
+  background: #e5e7eb;
+}
+
 .date-badge {
   position: absolute;
   bottom: -15px;

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -9,7 +9,6 @@
     <div class="header-actions">
       <button
         class="create-event-btn"
-        *ngIf="events.length > 0"
         (click)="openCreateEvent()">
         Create an event
       </button>
@@ -45,8 +44,7 @@
 
         <div class="form-group">
           <input
-            type="text"
-            placeholder="Date (e.g., 25)"
+            type="date"
             [(ngModel)]="newEvent.date"
             name="date"
             #date="ngModel"
@@ -54,20 +52,6 @@
           />
           <div *ngIf="date.invalid && (date.dirty || date.touched)" class="error-message">
             Date is required.
-          </div>
-        </div>
-
-        <div class="form-group">
-          <input
-            type="text"
-            placeholder="Month (e.g., MAR)"
-            [(ngModel)]="newEvent.month"
-            name="month"
-            #month="ngModel"
-            required
-          />
-          <div *ngIf="month.invalid && (month.dirty || month.touched)" class="error-message">
-            Month is required.
           </div>
         </div>
 
@@ -114,10 +98,15 @@
           <img [src]="imagePreview" alt="Preview" />
         </div>
 
+        <div *ngIf="createEventError" class="error-message">
+          {{ createEventError }}
+        </div>
 
         <div class="modal-actions">
           <button type="button" (click)="closeCreateEvent()">Cancel</button>
-          <button type="submit" [disabled]="eventForm.invalid || !!imageError">Create</button>
+          <button type="submit" [disabled]="eventForm.invalid || !!imageError || isCreatingEvent">
+            {{ isCreatingEvent ? 'Creating...' : 'Create' }}
+          </button>
         </div>
 
       </form>
@@ -172,13 +161,17 @@
 
   </div>-->
 
-  <div *ngIf="eventsError" class="status-state error-state">
+  <div *ngIf="isLoadingEvents" class="status-state loading-state">
+    <p>Loading events...</p>
+  </div>
+
+  <div *ngIf="!isLoadingEvents && eventsError" class="status-state error-state">
     <p>{{ eventsError }}</p>
     <button type="button" class="create-event-btn" (click)="fetchEvents()">Retry</button>
   </div>
 
   <!-- EVENTS GRID -->
-  <div *ngIf="!eventsError">
+  <div *ngIf="!isLoadingEvents && !eventsError">
     <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
       {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
     </div>
@@ -188,7 +181,8 @@
       <div class="event-card" *ngFor="let event of displayedEvents">
 
         <div class="image-wrapper">
-          <img [src]="event.imageUrl" [alt]="event.name">
+          <img *ngIf="event.imageUrl" [src]="event.imageUrl" [alt]="event.name">
+          <div *ngIf="!event.imageUrl" class="image-placeholder"></div>
 
           <div class="date-badge">
             <span class="day">{{ event.date }}</span>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,11 +1,11 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { finalize, Subscription } from 'rxjs';
+import { distinctUntilChanged, finalize, map, Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
-import { CommunityEvent, EventService } from '../../services/event.service';
+import { CommunityEvent, CreateEventPayload, EventService } from '../../services/event.service';
 
 interface EventItem {
   id: number;
@@ -34,32 +34,40 @@ export class EventsComponent implements OnInit, OnDestroy {
   eventsError = '';
 
   imagePreview: string | null = null;
+  selectedImageFile: File | null = null;
   imageError = '';
+  createEventError = '';
+  isCreatingEvent = false;
   private currentUserId = '';
-  private routeSubscription?: Subscription;
+  private refreshSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
 
   constructor(
     private readonly route: ActivatedRoute,
     private readonly eventService: EventService,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
     this.loadCurrentUserContext();
-    this.routeSubscription = this.route.queryParamMap.subscribe(() => {
-      this.fetchEvents();
-    });
+    this.refreshSubscription = this.route.queryParamMap
+      .pipe(
+        map((params) => params.get('refresh') ?? ''),
+        distinctUntilChanged()
+      )
+      .subscribe(() => {
+        this.fetchEvents();
+      });
   }
 
   ngOnDestroy(): void {
-    this.routeSubscription?.unsubscribe();
+    this.refreshSubscription?.unsubscribe();
   }
 
   newEvent = {
     name: '',
     date: '',
-    month: '',
     time: '',
     location: '',
     interested: 0,
@@ -85,12 +93,18 @@ export class EventsComponent implements OnInit, OnDestroy {
       .getEvents()
       .pipe(finalize(() => {
         this.isLoadingEvents = false;
+        this.cdr.detectChanges();
       }))
       .subscribe({
         next: (events) => {
-          this.events = events
-            .filter((event) => this.isUpcomingEvent(event.date))
-            .map((event) => this.mapToEventItem(event));
+          try {
+            const normalizedEvents = Array.isArray(events) ? events : [];
+            this.events = normalizedEvents.map((event) => this.mapToEventItem(event));
+          } catch (error) {
+            console.error(error);
+            this.eventsError = 'Failed to load events.';
+            this.events = [];
+          }
         },
         error: (error: unknown) => {
           console.error(error);
@@ -110,6 +124,7 @@ export class EventsComponent implements OnInit, OnDestroy {
   openCreateEvent(): void {
     this.showCreateEventForm = true;
     this.imageError = '';
+    this.createEventError = '';
   }
 
   closeCreateEvent(): void {
@@ -122,6 +137,9 @@ export class EventsComponent implements OnInit, OnDestroy {
 
     if (!input.files || input.files.length === 0) {
       this.imageError = '';
+      this.selectedImageFile = null;
+      this.imagePreview = null;
+      this.newEvent.imageUrl = '';
       return;
     }
 
@@ -130,11 +148,14 @@ export class EventsComponent implements OnInit, OnDestroy {
     if (!file.type.startsWith('image/')) {
       this.imageError = 'Please upload a valid image file.';
       this.imagePreview = null;
+      this.selectedImageFile = null;
       this.newEvent.imageUrl = '';
       return;
     }
 
     this.imageError = '';
+    this.createEventError = '';
+    this.selectedImageFile = file;
 
     const reader = new FileReader();
 
@@ -147,36 +168,60 @@ export class EventsComponent implements OnInit, OnDestroy {
   }
 
   createEvent(eventForm: NgForm): void {
-    if (eventForm.invalid || this.imageError) {
+    if (eventForm.invalid || this.imageError || this.isCreatingEvent) {
       eventForm.control.markAllAsTouched();
       return;
     }
 
-    const newEventWithId: EventItem = {
-      id: Date.now(),
-      ...this.newEvent,
-      createdByUser: true
+    const payload: CreateEventPayload = {
+      title: this.newEvent.name.trim(),
+      date: this.newEvent.date.trim(),
+      time: this.newEvent.time.trim(),
+      location: this.newEvent.location.trim(),
+      image: this.selectedImageFile
     };
 
-    this.events = [newEventWithId, ...this.events];
+    if (!payload.title || !payload.date || !payload.time || !payload.location) {
+      this.createEventError = 'All required fields must be filled.';
+      eventForm.control.markAllAsTouched();
+      return;
+    }
 
-    this.resetForm();
-    eventForm.resetForm();
-    this.showCreateEventForm = false;
+    this.isCreatingEvent = true;
+    this.createEventError = '';
+
+    this.eventService
+      .createEvent(payload)
+      .pipe(finalize(() => {
+        this.isCreatingEvent = false;
+      }))
+      .subscribe({
+        next: (createdEvent) => {
+          this.events = [this.mapToEventItem(createdEvent), ...this.events];
+          this.resetForm();
+          eventForm.resetForm();
+          this.showCreateEventForm = false;
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.createEventError = this.getCreateErrorMessage(error);
+        }
+      });
   }
 
   private resetForm(): void {
     this.newEvent = {
       name: '',
       date: '',
-      month: '',
       time: '',
       location: '',
       interested: 0,
       imageUrl: ''
     };
     this.imagePreview = null;
+    this.selectedImageFile = null;
     this.imageError = '';
+    this.createEventError = '';
   }
 
   private mapToEventItem(event: CommunityEvent): EventItem {
@@ -221,24 +266,6 @@ export class EventsComponent implements OnInit, OnDestroy {
     return { day: trimmed, month: '' };
   }
 
-  private isUpcomingEvent(dateValue: string): boolean {
-    const trimmed = dateValue.trim();
-    if (!trimmed) {
-      return true;
-    }
-
-    const parsed = new Date(trimmed);
-    if (Number.isNaN(parsed.getTime())) {
-      return true;
-    }
-
-    const eventDay = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
-    const today = new Date();
-    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
-
-    return eventDay >= todayStart;
-  }
-
   private loadCurrentUserContext(): void {
     const user = this.authService.getStoredUser();
     this.currentUserId = user ? `${user.id}` : '';
@@ -266,4 +293,32 @@ export class EventsComponent implements OnInit, OnDestroy {
 
     return 'Failed to load events.';
   }
+
+  private getCreateErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to create event. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to create an event.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to create event. Please try again.';
+  }
+
 }

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
 import { AuthService } from '../../services/auth.service';
-import { CommunityEvent, EventService } from '../../services/event.service';
+import { CommunityEvent, CreateEventPayload, EventService } from '../../services/event.service';
 
 describe('EventsComponent', () => {
   let component: EventsComponent;
@@ -13,8 +13,20 @@ describe('EventsComponent', () => {
   let routeQueryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
+    createEvent: (payload: CreateEventPayload) => Observable<CommunityEvent>;
   } = {
-    getEvents: () => of([])
+    getEvents: () => of([]),
+    createEvent: (payload: CreateEventPayload) =>
+      of({
+        id: 999,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      })
   };
   const authServiceStub: {
     getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
@@ -24,6 +36,17 @@ describe('EventsComponent', () => {
 
   beforeEach(async () => {
     eventServiceStub.getEvents = () => of([]);
+    eventServiceStub.createEvent = (payload: CreateEventPayload) =>
+      of({
+        id: 999,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      });
     authServiceStub.getStoredUser = () => null;
     routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
@@ -115,6 +138,22 @@ describe('EventsComponent', () => {
     expect(component.eventsError).toBe('Unable to reach the backend. Make sure the API is running.');
   });
 
+  it('should show loading state while events are being fetched', () => {
+    eventServiceStub.getEvents = () =>
+      new Observable<CommunityEvent[]>(() => {
+        return () => undefined;
+      });
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const loadingState = compiled.querySelector('.loading-state');
+    const hostCard = compiled.querySelector('.host-card');
+
+    expect(loadingState?.textContent).toContain('Loading events...');
+    expect(hostCard).toBeNull();
+  });
+
   it('should show only host card when there are no events', () => {
     fixture.detectChanges();
 
@@ -199,7 +238,47 @@ describe('EventsComponent', () => {
     expect(emptyNote).toBeNull();
   });
 
-  it('should not render past events from the API', () => {
+  it('should show all events in default view including user-created ones', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 2,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1,
+          title: 'My Event',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '2',
+          created_at: '2026-04-10T14:23:15Z'
+        },
+        {
+          id: 2,
+          title: 'Other Event',
+          date: '2099-04-21',
+          time: '8:00 AM',
+          location: 'Depot Park',
+          image_url: '/uploads/other.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:16Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+
+    expect(component.displayedEvents.length).toBe(2);
+    expect(eventCards.length).toBe(2);
+  });
+
+  it('should keep past and upcoming events from the API', () => {
     eventServiceStub.getEvents = () =>
       of([
         {
@@ -226,8 +305,9 @@ describe('EventsComponent', () => {
 
     fixture.detectChanges();
 
-    expect(component.events.length).toBe(1);
-    expect(component.events[0].name).toBe('Upcoming Event');
+    expect(component.events.length).toBe(2);
+    expect(component.events[0].name).toBe('Old Event');
+    expect(component.events[1].name).toBe('Upcoming Event');
   });
 
   it('should keep form invalid when required fields are empty', () => {
@@ -241,12 +321,32 @@ describe('EventsComponent', () => {
     expect(form.checkValidity()).toBe(false);
   });
 
-  it('should create a user event and reset the form state', () => {
+  it('should create an event via API and reset form state', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    const createEventSpy = vi.fn((payload: CreateEventPayload) =>
+      of({
+        id: 4001,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '/uploads/new.jpg',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      })
+    );
+    eventServiceStub.createEvent = createEventSpy;
+
+    fixture.detectChanges();
     const initialEventCount = component.events.length;
     component.newEvent = {
       name: 'Neighborhood Cleanup',
-      date: '30',
-      month: 'APR',
+      date: '2026-04-30',
       time: '10:00 AM',
       location: 'Depot Park',
       interested: 0,
@@ -260,38 +360,75 @@ describe('EventsComponent', () => {
 
     component.createEvent(mockForm as never);
 
+    expect(createEventSpy).toHaveBeenCalledTimes(1);
     expect(component.events.length).toBe(initialEventCount + 1);
     expect(component.events[0].createdByUser).toBe(true);
+    expect(component.events[0].imageUrl).toBe('/uploads/new.jpg');
     expect(component.showCreateEventForm).toBe(false);
     expect(component.newEvent.name).toBe('');
   });
 
-  it('should show delete button only for user-created events', () => {
+  it('should show create error when API event creation fails', () => {
+    eventServiceStub.createEvent = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 401
+          })
+      );
+
     fixture.detectChanges();
-    component.events = [
-      {
-        id: 1001,
-        name: 'User Event',
-        date: '15',
-        month: 'APR',
-        time: '5:00 PM',
-        location: 'UF Campus',
-        interested: 10,
-        imageUrl: 'https://example.com/user-event.jpg',
-        createdByUser: true
-      },
-      {
-        id: 1002,
-        name: 'Community Event',
-        date: '16',
-        month: 'APR',
-        time: '6:00 PM',
-        location: 'Downtown',
-        interested: 20,
-        imageUrl: 'https://example.com/community-event.jpg',
-        createdByUser: false
-      }
-    ];
+    component.newEvent = {
+      name: 'Neighborhood Cleanup',
+      date: '2026-04-30',
+      time: '10:00 AM',
+      location: 'Depot Park',
+      interested: 0,
+      imageUrl: ''
+    };
+    const mockForm = {
+      invalid: false,
+      control: { markAllAsTouched: () => undefined },
+      resetForm: () => undefined
+    };
+
+    component.createEvent(mockForm as never);
+
+    expect(component.createEventError).toBe('You must be logged in to create an event.');
+    expect(component.showCreateEventForm).toBe(false);
+  });
+
+  it('should show delete button only for user-created events', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1001,
+          title: 'User Event',
+          date: '2099-04-15',
+          time: '5:00 PM',
+          location: 'UF Campus',
+          image_url: 'https://example.com/user-event.jpg',
+          author: '1',
+          created_at: '2026-04-10T14:23:15Z'
+        },
+        {
+          id: 1002,
+          title: 'Community Event',
+          date: '2099-04-16',
+          time: '6:00 PM',
+          location: 'Downtown',
+          image_url: 'https://example.com/community-event.jpg',
+          author: '2',
+          created_at: '2026-04-10T14:23:16Z'
+        }
+      ]);
+
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -3,6 +3,10 @@ import { firstValueFrom, of } from 'rxjs';
 import { EventService } from './event.service';
 
 describe('EventService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('normalizes snake_case event payload fields', async () => {
     let requestedUrl = '';
     const httpClientStub = {
@@ -75,5 +79,116 @@ describe('EventService', () => {
       updated_at: '2026-05-01T13:35:00Z',
       deleted_at: null
     });
+  });
+
+  it('posts multipart event creation payload with auth token and normalizes response', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-123');
+
+    let postedUrl = '';
+    let postedTitle = '';
+    let postedDate = '';
+    let postedTime = '';
+    let postedLocation = '';
+    let postedImageName = '';
+    const postedHeaders: { Authorization?: string } = {};
+
+    const imageFile = new File(['image-content'], 'event.jpg', { type: 'image/jpeg' });
+    const httpClientStub = {
+      get: () => of([]),
+      post: (url: string, body: unknown, options?: { headers?: { get(name: string): string | null } }) => {
+        postedUrl = url;
+        if (body instanceof FormData) {
+          postedTitle = String(body.get('title') ?? '');
+          postedDate = String(body.get('date') ?? '');
+          postedTime = String(body.get('time') ?? '');
+          postedLocation = String(body.get('location') ?? '');
+          const image = body.get('image');
+          if (image instanceof File) {
+            postedImageName = image.name;
+          }
+        }
+        const auth = options?.headers?.get('Authorization');
+        if (auth) {
+          postedHeaders['Authorization'] = auth;
+        }
+        return of({
+          ID: 77,
+          Title: 'Neighborhood Cleanup',
+          Date: '2026-05-12',
+          Time: '10:00 AM',
+          Location: 'Depot Park',
+          ImageURL: '/uploads/new-event.jpg',
+          Author: '5',
+          CreatedAt: '2026-05-01T13:30:00Z',
+          UpdatedAt: '2026-05-01T13:30:00Z',
+          DeletedAt: null
+        });
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const created = await firstValueFrom(
+      service.createEvent({
+        title: 'Neighborhood Cleanup',
+        date: '2026-05-12',
+        time: '10:00 AM',
+        location: 'Depot Park',
+        image: imageFile
+      })
+    );
+
+    expect(postedUrl).toBe('/api/events');
+    expect(postedTitle).toBe('Neighborhood Cleanup');
+    expect(postedDate).toBe('2026-05-12');
+    expect(postedTime).toBe('10:00 AM');
+    expect(postedLocation).toBe('Depot Park');
+    expect(postedImageName).toBe('event.jpg');
+    expect(postedHeaders['Authorization']).toBe('Bearer jwt-token-123');
+    expect(created).toEqual({
+      id: 77,
+      title: 'Neighborhood Cleanup',
+      date: '2026-05-12',
+      time: '10:00 AM',
+      location: 'Depot Park',
+      image_url: '/uploads/new-event.jpg',
+      author: '5',
+      created_at: '2026-05-01T13:30:00Z',
+      updated_at: '2026-05-01T13:30:00Z',
+      deleted_at: null
+    });
+  });
+
+  it('normalizes relative upload paths to absolute /uploads paths', async () => {
+    const httpClientStub = {
+      get: () =>
+        of([
+          {
+            id: 5,
+            title: 'Movie Night',
+            date: '2026-06-02',
+            time: '8:00 PM',
+            location: 'Town Square',
+            image_url: 'uploads/movie-night.jpg',
+            author: 3,
+            created_at: '2026-06-01T10:00:00Z'
+          },
+          {
+            id: 6,
+            title: 'Picnic',
+            date: '2026-06-03',
+            time: '11:00 AM',
+            location: 'Lake Park',
+            image_url: './uploads/picnic.jpg',
+            author: 3,
+            created_at: '2026-06-01T11:00:00Z'
+          }
+        ])
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(events[0].image_url).toBe('/uploads/movie-night.jpg');
+    expect(events[1].image_url).toBe('/uploads/picnic.jpg');
   });
 });

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiConfig } from '../config/api.config';
 
@@ -40,22 +40,50 @@ export interface CommunityEvent {
   deleted_at?: string | null;
 }
 
+export interface CreateEventPayload {
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  image?: File | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class EventService {
   private readonly apiUrl = `${ApiConfig.baseUrl}/events`;
+  private readonly tokenKey = 'auth_token';
 
   constructor(private readonly http: HttpClient) {}
 
+  private normalizeImageUrl(rawImageUrl: string | undefined): string {
+    const value = (rawImageUrl ?? '').trim();
+    if (!value) {
+      return '';
+    }
+
+    if (/^https?:\/\//i.test(value) || value.startsWith('data:')) {
+      return value;
+    }
+
+    const normalizedPath = value.replaceAll('\\', '/').replace(/^\.?\//, '');
+    if (normalizedPath.startsWith('uploads/')) {
+      return `/${normalizedPath}`;
+    }
+
+    return value;
+  }
+
   private normalizeEvent(raw: RawEvent): CommunityEvent {
+    const rawImageUrl = raw.image_url ?? raw.imageUrl ?? raw.ImageURL;
     return {
       id: raw.id ?? raw.ID ?? 0,
       title: (raw.title ?? raw.Title ?? '').trim() || 'Community Event',
       date: raw.date ?? raw.Date ?? '',
       time: raw.time ?? raw.Time ?? '',
       location: raw.location ?? raw.Location ?? '',
-      image_url: raw.image_url ?? raw.imageUrl ?? raw.ImageURL ?? '',
+      image_url: this.normalizeImageUrl(rawImageUrl),
       author: String(raw.author ?? raw.Author ?? ''),
       created_at: raw.created_at ?? raw.CreatedAt ?? '',
       updated_at: raw.updated_at ?? raw.UpdatedAt,
@@ -65,7 +93,30 @@ export class EventService {
 
   getEvents(): Observable<CommunityEvent[]> {
     return this.http
-      .get<RawEvent[]>(this.apiUrl)
-      .pipe(map((events) => events.map((event) => this.normalizeEvent(event))));
+      .get<RawEvent[] | null>(this.apiUrl)
+      .pipe(map((events) => (events ?? []).map((event) => this.normalizeEvent(event))));
+  }
+
+  createEvent(payload: CreateEventPayload): Observable<CommunityEvent> {
+    const formData = new FormData();
+    formData.append('title', payload.title);
+    formData.append('date', payload.date);
+    formData.append('time', payload.time);
+    formData.append('location', payload.location);
+
+    if (payload.image) {
+      formData.append('image', payload.image);
+    }
+
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http
+      .post<RawEvent>(this.apiUrl, formData, { headers })
+      .pipe(map((event) => this.normalizeEvent(event)));
   }
 }


### PR DESCRIPTION
## Summary
Integrated Create Event functionality with backend API to allow users to create and store events.

## Changes

- Connected Create Event form to `POST /api/events` endpoint
- Added authentication token to request headers
- Implemented form submission with required fields (title, date, time, location)
- Added optional image upload support
- Updated UI after successful event creation
- Reset form on successful submission
- Added error handling for failed requests

## Behavior/Features

- Users can create events that are saved in the backend
- UI updates dynamically after event creation
- Form resets after successful submission
- Errors are handled and displayed appropriately

## Preview

<img width="1250" height="763" alt="Screenshot 2026-04-27 at 11 47 52 PM" src="https://github.com/user-attachments/assets/8ef98386-6eb9-46a1-af7a-48c13e077451" />


Closes #106 