### PR TITLE
107 fe 30 delete event using backend api

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -18,6 +18,7 @@
           "builder": "@angular/build:application",
           "options": {
             "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "@types/leaflet": "^1.9.21",
         "leaflet": "^1.9.4",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "zone.js": "^0.16.1"
       },
       "devDependencies": {
         "@angular/build": "^21.1.3",
@@ -10499,6 +10500,12 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
+      "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,8 @@
     "@types/leaflet": "^1.9.21",
     "leaflet": "^1.9.4",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "zone.js": "^0.16.1"
   },
   "devDependencies": {
     "@angular/build": "^21.1.3",

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -4,5 +4,11 @@
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
+  },
+  "/uploads": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
   }
 }

--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -99,6 +99,12 @@
   object-fit: cover;
 }
 
+.image-placeholder {
+  width: 100%;
+  height: 100%;
+  background: #e5e7eb;
+}
+
 .date-badge {
   position: absolute;
   bottom: -15px;

--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -52,6 +52,12 @@
   font-size: 14px;
 }
 
+.events-delete-error {
+  margin: 0 0 14px;
+  color: #b91c1c;
+  font-size: 14px;
+}
+
 .status-state {
   background: #ffffff;
   border: 1px solid #e5e7eb;
@@ -352,6 +358,11 @@
 
 .delete-btn:hover {
   background: #fecaca;
+}
+
+.delete-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -46,6 +46,36 @@
   gap: 24px;
 }
 
+.events-empty-note {
+  margin: 0 0 14px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.status-state {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 24px;
+  text-align: center;
+  max-width: 500px;
+  margin: 24px auto 0;
+}
+
+.loading-state {
+  color: #374151;
+}
+
+.error-state {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.error-state p {
+  color: #b91c1c;
+  margin: 0 0 14px 0;
+}
+
 .event-card {
   background: #ffffff;
   border-radius: 16px;

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -9,7 +9,6 @@
     <div class="header-actions">
       <button
         class="create-event-btn"
-        *ngIf="events.length > 0"
         (click)="openCreateEvent()">
         Create an event
       </button>
@@ -45,8 +44,7 @@
 
         <div class="form-group">
           <input
-            type="text"
-            placeholder="Date (e.g., 25)"
+            type="date"
             [(ngModel)]="newEvent.date"
             name="date"
             #date="ngModel"
@@ -54,20 +52,6 @@
           />
           <div *ngIf="date.invalid && (date.dirty || date.touched)" class="error-message">
             Date is required.
-          </div>
-        </div>
-
-        <div class="form-group">
-          <input
-            type="text"
-            placeholder="Month (e.g., MAR)"
-            [(ngModel)]="newEvent.month"
-            name="month"
-            #month="ngModel"
-            required
-          />
-          <div *ngIf="month.invalid && (month.dirty || month.touched)" class="error-message">
-            Month is required.
           </div>
         </div>
 
@@ -114,10 +98,15 @@
           <img [src]="imagePreview" alt="Preview" />
         </div>
 
+        <div *ngIf="createEventError" class="error-message">
+          {{ createEventError }}
+        </div>
 
         <div class="modal-actions">
           <button type="button" (click)="closeCreateEvent()">Cancel</button>
-          <button type="submit" [disabled]="eventForm.invalid || !!imageError">Create</button>
+          <button type="submit" [disabled]="eventForm.invalid || !!imageError || isCreatingEvent">
+            {{ isCreatingEvent ? 'Creating...' : 'Create' }}
+          </button>
         </div>
 
       </form>
@@ -172,13 +161,17 @@
 
   </div>-->
 
-  <div *ngIf="eventsError" class="status-state error-state">
+  <div *ngIf="isLoadingEvents" class="status-state loading-state">
+    <p>Loading events...</p>
+  </div>
+
+  <div *ngIf="!isLoadingEvents && eventsError" class="status-state error-state">
     <p>{{ eventsError }}</p>
     <button type="button" class="create-event-btn" (click)="fetchEvents()">Retry</button>
   </div>
 
   <!-- EVENTS GRID -->
-  <div *ngIf="!eventsError">
+  <div *ngIf="!isLoadingEvents && !eventsError">
     <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
       {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
     </div>
@@ -188,7 +181,8 @@
       <div class="event-card" *ngFor="let event of displayedEvents">
 
         <div class="image-wrapper">
-          <img [src]="event.imageUrl" [alt]="event.name">
+          <img *ngIf="event.imageUrl" [src]="event.imageUrl" [alt]="event.name">
+          <div *ngIf="!event.imageUrl" class="image-placeholder"></div>
 
           <div class="date-badge">
             <span class="day">{{ event.date }}</span>

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -172,8 +172,16 @@
 
   </div>-->
 
-  <!-- EVENTS GRID WITH EMPTY STATE -->
-  <div *ngIf="displayedEvents.length > 0; else emptyState">
+  <div *ngIf="eventsError" class="status-state error-state">
+    <p>{{ eventsError }}</p>
+    <button type="button" class="create-event-btn" (click)="fetchEvents()">Retry</button>
+  </div>
+
+  <!-- EVENTS GRID -->
+  <div *ngIf="!eventsError">
+    <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
+      {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
+    </div>
 
     <div class="events-grid">
 
@@ -221,26 +229,6 @@
       </div>
 
     </div>
-
   </div>
-
-  <!-- EMPTY STATE -->
-  <ng-template #emptyState>
-    <div class="empty-state">
-      <h3>
-        {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
-      </h3>
-
-      <p>
-        {{ showOnlyUserEvents
-        ? "You haven't created any events yet. Start by creating one."
-        : "There are no events to display right now." }}
-      </p>
-
-      <button class="create-event-btn" (click)="openCreateEvent()">
-        Create an event
-      </button>
-    </div>
-  </ng-template>
 
 </section>

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -172,6 +172,10 @@
 
   <!-- EVENTS GRID -->
   <div *ngIf="!isLoadingEvents && !eventsError">
+    <div class="events-delete-error" *ngIf="deleteEventError">
+      {{ deleteEventError }}
+    </div>
+
     <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
       {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
     </div>
@@ -205,8 +209,9 @@
               *ngIf="event.createdByUser"
               type="button"
               class="delete-btn"
+              [disabled]="deletingEventIds.has(event.id)"
               (click)="deleteEvent(event.id)">
-              Delete
+              {{ deletingEventIds.has(event.id) ? 'Deleting...' : 'Delete' }}
             </button>
           </div>
         </div>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,8 +1,9 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
-import { finalize } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { finalize, Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { CommunityEvent, EventService } from '../../services/event.service';
 
@@ -26,7 +27,7 @@ interface EventItem {
   templateUrl: './events.component.html',
   styleUrl: './events.component.css'
 })
-export class EventsComponent implements OnInit {
+export class EventsComponent implements OnInit, OnDestroy {
   showCreateEventForm = false;
   showOnlyUserEvents = false;
   isLoadingEvents = false;
@@ -35,16 +36,24 @@ export class EventsComponent implements OnInit {
   imagePreview: string | null = null;
   imageError = '';
   private currentUserId = '';
+  private routeSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
 
   constructor(
+    private readonly route: ActivatedRoute,
     private readonly eventService: EventService,
     private readonly authService: AuthService
   ) {}
 
   ngOnInit(): void {
     this.loadCurrentUserContext();
-    this.fetchEvents();
+    this.routeSubscription = this.route.queryParamMap.subscribe(() => {
+      this.fetchEvents();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
   }
 
   newEvent = {

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -37,7 +37,9 @@ export class EventsComponent implements OnInit, OnDestroy {
   selectedImageFile: File | null = null;
   imageError = '';
   createEventError = '';
+  deleteEventError = '';
   isCreatingEvent = false;
+  deletingEventIds = new Set<number>();
   private currentUserId = '';
   private refreshSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
@@ -75,19 +77,43 @@ export class EventsComponent implements OnInit, OnDestroy {
   };
 
   deleteEvent(id: number): void {
-    const confirmDelete = confirm('Are you sure you want to delete this event?');
+    if (this.deletingEventIds.has(id)) {
+      return;
+    }
+
+    const confirmDelete = window.confirm('Are you sure you want to delete this event?');
 
     if (!confirmDelete) {
       return;
     }
 
-    this.events = this.events.filter(event => event.id !== id);
+    this.deleteEventError = '';
+    this.deletingEventIds = new Set(this.deletingEventIds).add(id);
+
+    this.eventService
+      .deleteEvent(id)
+      .pipe(finalize(() => {
+        const nextDeletingIds = new Set(this.deletingEventIds);
+        nextDeletingIds.delete(id);
+        this.deletingEventIds = nextDeletingIds;
+        this.cdr.detectChanges();
+      }))
+      .subscribe({
+        next: () => {
+          this.events = this.events.filter(event => String(event.id) !== String(id));
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.deleteEventError = this.getDeleteErrorMessage(error);
+        }
+      });
   }
   events: EventItem[] = [];
 
   fetchEvents(): void {
     this.isLoadingEvents = true;
     this.eventsError = '';
+    this.deleteEventError = '';
 
     this.eventService
       .getEvents()
@@ -125,6 +151,7 @@ export class EventsComponent implements OnInit, OnDestroy {
     this.showCreateEventForm = true;
     this.imageError = '';
     this.createEventError = '';
+    this.deleteEventError = '';
   }
 
   closeCreateEvent(): void {
@@ -319,6 +346,37 @@ export class EventsComponent implements OnInit, OnDestroy {
     }
 
     return 'Failed to create event. Please try again.';
+  }
+
+  private getDeleteErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to delete event. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to delete this event.';
+    }
+
+    if (error.status === 403) {
+      return 'You can only delete events you created.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to delete event. Please try again.';
   }
 
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,11 +1,11 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { finalize, Subscription } from 'rxjs';
+import { distinctUntilChanged, finalize, map, Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
-import { CommunityEvent, EventService } from '../../services/event.service';
+import { CommunityEvent, CreateEventPayload, EventService } from '../../services/event.service';
 
 interface EventItem {
   id: number;
@@ -34,32 +34,40 @@ export class EventsComponent implements OnInit, OnDestroy {
   eventsError = '';
 
   imagePreview: string | null = null;
+  selectedImageFile: File | null = null;
   imageError = '';
+  createEventError = '';
+  isCreatingEvent = false;
   private currentUserId = '';
-  private routeSubscription?: Subscription;
+  private refreshSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
 
   constructor(
     private readonly route: ActivatedRoute,
     private readonly eventService: EventService,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
     this.loadCurrentUserContext();
-    this.routeSubscription = this.route.queryParamMap.subscribe(() => {
-      this.fetchEvents();
-    });
+    this.refreshSubscription = this.route.queryParamMap
+      .pipe(
+        map((params) => params.get('refresh') ?? ''),
+        distinctUntilChanged()
+      )
+      .subscribe(() => {
+        this.fetchEvents();
+      });
   }
 
   ngOnDestroy(): void {
-    this.routeSubscription?.unsubscribe();
+    this.refreshSubscription?.unsubscribe();
   }
 
   newEvent = {
     name: '',
     date: '',
-    month: '',
     time: '',
     location: '',
     interested: 0,
@@ -85,12 +93,18 @@ export class EventsComponent implements OnInit, OnDestroy {
       .getEvents()
       .pipe(finalize(() => {
         this.isLoadingEvents = false;
+        this.cdr.detectChanges();
       }))
       .subscribe({
         next: (events) => {
-          this.events = events
-            .filter((event) => this.isUpcomingEvent(event.date))
-            .map((event) => this.mapToEventItem(event));
+          try {
+            const normalizedEvents = Array.isArray(events) ? events : [];
+            this.events = normalizedEvents.map((event) => this.mapToEventItem(event));
+          } catch (error) {
+            console.error(error);
+            this.eventsError = 'Failed to load events.';
+            this.events = [];
+          }
         },
         error: (error: unknown) => {
           console.error(error);
@@ -110,6 +124,7 @@ export class EventsComponent implements OnInit, OnDestroy {
   openCreateEvent(): void {
     this.showCreateEventForm = true;
     this.imageError = '';
+    this.createEventError = '';
   }
 
   closeCreateEvent(): void {
@@ -122,6 +137,9 @@ export class EventsComponent implements OnInit, OnDestroy {
 
     if (!input.files || input.files.length === 0) {
       this.imageError = '';
+      this.selectedImageFile = null;
+      this.imagePreview = null;
+      this.newEvent.imageUrl = '';
       return;
     }
 
@@ -130,11 +148,14 @@ export class EventsComponent implements OnInit, OnDestroy {
     if (!file.type.startsWith('image/')) {
       this.imageError = 'Please upload a valid image file.';
       this.imagePreview = null;
+      this.selectedImageFile = null;
       this.newEvent.imageUrl = '';
       return;
     }
 
     this.imageError = '';
+    this.createEventError = '';
+    this.selectedImageFile = file;
 
     const reader = new FileReader();
 
@@ -147,36 +168,60 @@ export class EventsComponent implements OnInit, OnDestroy {
   }
 
   createEvent(eventForm: NgForm): void {
-    if (eventForm.invalid || this.imageError) {
+    if (eventForm.invalid || this.imageError || this.isCreatingEvent) {
       eventForm.control.markAllAsTouched();
       return;
     }
 
-    const newEventWithId: EventItem = {
-      id: Date.now(),
-      ...this.newEvent,
-      createdByUser: true
+    const payload: CreateEventPayload = {
+      title: this.newEvent.name.trim(),
+      date: this.newEvent.date.trim(),
+      time: this.newEvent.time.trim(),
+      location: this.newEvent.location.trim(),
+      image: this.selectedImageFile
     };
 
-    this.events = [newEventWithId, ...this.events];
+    if (!payload.title || !payload.date || !payload.time || !payload.location) {
+      this.createEventError = 'All required fields must be filled.';
+      eventForm.control.markAllAsTouched();
+      return;
+    }
 
-    this.resetForm();
-    eventForm.resetForm();
-    this.showCreateEventForm = false;
+    this.isCreatingEvent = true;
+    this.createEventError = '';
+
+    this.eventService
+      .createEvent(payload)
+      .pipe(finalize(() => {
+        this.isCreatingEvent = false;
+      }))
+      .subscribe({
+        next: (createdEvent) => {
+          this.events = [this.mapToEventItem(createdEvent), ...this.events];
+          this.resetForm();
+          eventForm.resetForm();
+          this.showCreateEventForm = false;
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.createEventError = this.getCreateErrorMessage(error);
+        }
+      });
   }
 
   private resetForm(): void {
     this.newEvent = {
       name: '',
       date: '',
-      month: '',
       time: '',
       location: '',
       interested: 0,
       imageUrl: ''
     };
     this.imagePreview = null;
+    this.selectedImageFile = null;
     this.imageError = '';
+    this.createEventError = '';
   }
 
   private mapToEventItem(event: CommunityEvent): EventItem {
@@ -221,24 +266,6 @@ export class EventsComponent implements OnInit, OnDestroy {
     return { day: trimmed, month: '' };
   }
 
-  private isUpcomingEvent(dateValue: string): boolean {
-    const trimmed = dateValue.trim();
-    if (!trimmed) {
-      return true;
-    }
-
-    const parsed = new Date(trimmed);
-    if (Number.isNaN(parsed.getTime())) {
-      return true;
-    }
-
-    const eventDay = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
-    const today = new Date();
-    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
-
-    return eventDay >= todayStart;
-  }
-
   private loadCurrentUserContext(): void {
     const user = this.authService.getStoredUser();
     this.currentUserId = user ? `${user.id}` : '';
@@ -266,4 +293,32 @@ export class EventsComponent implements OnInit, OnDestroy {
 
     return 'Failed to load events.';
   }
+
+  private getCreateErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to create event. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to create an event.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to create event. Please try again.';
+  }
+
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,6 +1,10 @@
-import { Component } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
+import { finalize } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+import { CommunityEvent, EventService } from '../../services/event.service';
 
 interface EventItem {
   id: number;
@@ -11,6 +15,7 @@ interface EventItem {
   location: string;
   interested: number;
   imageUrl: string;
+  author?: string;
   createdByUser?: boolean;
 }
 
@@ -21,12 +26,26 @@ interface EventItem {
   templateUrl: './events.component.html',
   styleUrl: './events.component.css'
 })
-export class EventsComponent {
+export class EventsComponent implements OnInit {
   showCreateEventForm = false;
   showOnlyUserEvents = false;
+  isLoadingEvents = false;
+  eventsError = '';
 
   imagePreview: string | null = null;
   imageError = '';
+  private currentUserId = '';
+  private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+  constructor(
+    private readonly eventService: EventService,
+    private readonly authService: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadCurrentUserContext();
+    this.fetchEvents();
+  }
 
   newEvent = {
     name: '',
@@ -47,56 +66,29 @@ export class EventsComponent {
 
     this.events = this.events.filter(event => event.id !== id);
   }
+  events: EventItem[] = [];
 
+  fetchEvents(): void {
+    this.isLoadingEvents = true;
+    this.eventsError = '';
 
-
-
-
-  events: EventItem[] = [
-    /* {
-      id: 1,
-      name: 'Block Party & BBQ',
-      date: '19',
-      month: 'FEB',
-      time: '9:15 AM',
-      location: 'Willow Creek Park',
-      interested: 45,
-      imageUrl:
-        'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 2,
-      name: 'Morning Yoga in the Park',
-      date: '20',
-      month: 'FEB',
-      time: '11:00 AM',
-      location: 'Community Center',
-      interested: 12,
-      imageUrl:
-        'https://images.unsplash.com/photo-1552196563-55cd4e45efb3?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 3,
-      name: 'Local Book Club Meeting',
-      date: '22',
-      month: 'FEB',
-      time: '6:30 PM',
-      location: 'Public Library',
-      interested: 8,
-      imageUrl:
-        'https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=1200&q=80'
-    },
-    {
-      id: 4,
-      name: 'Saturday Farmers Market',
-      date: '24',
-      month: 'FEB',
-      time: '8:00 AM',
-      location: 'Town Center',
-      interested: 124,
-      imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?auto=format&fit=crop&w=1200&q=80'
-    } */
-  ];
+    this.eventService
+      .getEvents()
+      .pipe(finalize(() => {
+        this.isLoadingEvents = false;
+      }))
+      .subscribe({
+        next: (events) => {
+          this.events = events
+            .filter((event) => this.isUpcomingEvent(event.date))
+            .map((event) => this.mapToEventItem(event));
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.eventsError = this.getFetchErrorMessage(error);
+        }
+      });
+  }
 
   get displayedEvents(): EventItem[] {
     if (this.showOnlyUserEvents) {
@@ -176,5 +168,93 @@ export class EventsComponent {
     };
     this.imagePreview = null;
     this.imageError = '';
+  }
+
+  private mapToEventItem(event: CommunityEvent): EventItem {
+    const badge = this.getDateBadge(event.date);
+    return {
+      id: event.id,
+      name: event.title,
+      date: badge.day,
+      month: badge.month,
+      time: event.time,
+      location: event.location,
+      interested: 0,
+      imageUrl: event.image_url,
+      author: event.author,
+      createdByUser: this.currentUserId !== '' && event.author === this.currentUserId
+    };
+  }
+
+  private getDateBadge(dateValue: string): { day: string; month: string } {
+    const trimmed = dateValue.trim();
+    if (!trimmed) {
+      return { day: '', month: '' };
+    }
+
+    const isoDateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoDateMatch) {
+      const monthIndex = Number(isoDateMatch[2]) - 1;
+      return {
+        day: String(Number(isoDateMatch[3])).padStart(2, '0'),
+        month: this.monthLabels[monthIndex] ?? ''
+      };
+    }
+
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        day: String(parsed.getDate()).padStart(2, '0'),
+        month: this.monthLabels[parsed.getMonth()] ?? ''
+      };
+    }
+
+    return { day: trimmed, month: '' };
+  }
+
+  private isUpcomingEvent(dateValue: string): boolean {
+    const trimmed = dateValue.trim();
+    if (!trimmed) {
+      return true;
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      return true;
+    }
+
+    const eventDay = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
+    const today = new Date();
+    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+
+    return eventDay >= todayStart;
+  }
+
+  private loadCurrentUserContext(): void {
+    const user = this.authService.getStoredUser();
+    this.currentUserId = user ? `${user.id}` : '';
+  }
+
+  private getFetchErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to load events.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to load events.';
   }
 }

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -1,14 +1,41 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
+import { AuthService } from '../../services/auth.service';
+import { CommunityEvent, EventService } from '../../services/event.service';
 
 describe('EventsComponent', () => {
   let component: EventsComponent;
   let fixture: ComponentFixture<EventsComponent>;
+  const eventServiceStub: {
+    getEvents: () => Observable<CommunityEvent[]>;
+  } = {
+    getEvents: () => of([])
+  };
+  const authServiceStub: {
+    getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
+  } = {
+    getStoredUser: () => null
+  };
 
   beforeEach(async () => {
+    eventServiceStub.getEvents = () => of([]);
+    authServiceStub.getStoredUser = () => null;
+
     await TestBed.configureTestingModule({
-      imports: [EventsComponent]
+      imports: [EventsComponent],
+      providers: [
+        {
+          provide: EventService,
+          useValue: eventServiceStub
+        },
+        {
+          provide: AuthService,
+          useValue: authServiceStub
+        }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(EventsComponent);
@@ -19,41 +46,168 @@ describe('EventsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show no-events empty state by default', () => {
+  it('should fetch and map backend events to UI fields on init', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 7,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1,
+          title: 'Community BBQ',
+          date: '2099-04-20',
+          time: '5:00 PM',
+          location: 'Central Park Pavilion',
+          image_url: '/uploads/1712345678_abc123.jpg',
+          author: '7',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    expect(component.events.length).toBe(1);
+    expect(component.events[0].name).toBe('Community BBQ');
+    expect(component.events[0].date).toBe('20');
+    expect(component.events[0].month).toBe('APR');
+    expect(component.events[0].imageUrl).toBe('/uploads/1712345678_abc123.jpg');
+    expect(component.events[0].createdByUser).toBe(true);
+  });
+
+  it('should show error state when fetch fails', () => {
+    eventServiceStub.getEvents = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 0
+          })
+      );
+
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyState = compiled.querySelector('.empty-state');
+    const errorState = compiled.querySelector('.error-state');
 
-    expect(emptyState).not.toBeNull();
-    expect(emptyState?.textContent).toContain('No events available');
+    expect(errorState).not.toBeNull();
+    expect(component.eventsError).toBe('Unable to reach the backend. Make sure the API is running.');
   });
 
-  it('should show empty state when viewing only user events and none exist', () => {
+  it('should show only host card when there are no events', () => {
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const hostCard = compiled.querySelector('.host-card');
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
+
+    expect(hostCard).not.toBeNull();
+    expect(eventCards.length).toBe(0);
+    expect(emptyNote?.textContent).toContain('No events available');
+  });
+
+  it('should show \"No events created yet\" when filtering to your events with none present', () => {
     component.showOnlyUserEvents = true;
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyState = compiled.querySelector('.empty-state');
+    const hostCard = compiled.querySelector('.host-card');
+    const emptyNote = compiled.querySelector('.events-empty-note');
 
-    expect(emptyState).not.toBeNull();
-    expect(emptyState?.textContent).toContain('No events created yet');
-    expect(compiled.querySelector('.header-actions .create-event-btn')).toBeNull();
+    expect(hostCard).not.toBeNull();
+    expect(emptyNote?.textContent).toContain('No events created yet');
   });
 
-  it('should open create event modal from empty state action', () => {
+  it('should show fetched events and keep host card at the end', () => {
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 10,
+          title: 'Morning Yoga in the Park',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const hostCard = compiled.querySelector('.host-card');
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
+
+    expect(eventCards.length).toBe(1);
+    expect(hostCard).not.toBeNull();
+    expect(emptyNote).toBeNull();
+  });
+
+  it('should hide empty note when showing only user events that exist', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 3,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 10,
+          title: 'My Event',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:15Z'
+        }
+      ]);
+
     component.showOnlyUserEvents = true;
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    const emptyStateCreateButton = compiled.querySelector('.empty-state .create-event-btn') as HTMLButtonElement;
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+    const emptyNote = compiled.querySelector('.events-empty-note');
 
-    emptyStateCreateButton.click();
-    fixture.detectChanges();
+    expect(eventCards.length).toBe(1);
+    expect(emptyNote).toBeNull();
+  });
+
+  it('should not render past events from the API', () => {
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 11,
+          title: 'Old Event',
+          date: '2000-01-01',
+          time: '8:00 AM',
+          location: 'Old Park',
+          image_url: '',
+          author: '2',
+          created_at: '2000-01-01T10:00:00Z'
+        },
+        {
+          id: 12,
+          title: 'Upcoming Event',
+          date: '2099-01-01',
+          time: '9:00 AM',
+          location: 'Future Park',
+          image_url: '',
+          author: '2',
+          created_at: '2098-12-01T10:00:00Z'
+        }
+      ]);
+
     fixture.detectChanges();
 
-    expect(component.showCreateEventForm).toBe(true);
-    expect(compiled.querySelector('.event-modal-overlay')).not.toBeNull();
+    expect(component.events.length).toBe(1);
+    expect(component.events[0].name).toBe('Upcoming Event');
   });
 
   it('should keep form invalid when required fields are empty', () => {
@@ -93,6 +247,7 @@ describe('EventsComponent', () => {
   });
 
   it('should show delete button only for user-created events', () => {
+    fixture.detectChanges();
     component.events = [
       {
         id: 1001,
@@ -117,7 +272,6 @@ describe('EventsComponent', () => {
         createdByUser: false
       }
     ];
-    fixture.detectChanges();
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -14,6 +14,7 @@ describe('EventsComponent', () => {
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
     createEvent: (payload: CreateEventPayload) => Observable<CommunityEvent>;
+    deleteEvent: (id: number) => Observable<void>;
   } = {
     getEvents: () => of([]),
     createEvent: (payload: CreateEventPayload) =>
@@ -26,7 +27,8 @@ describe('EventsComponent', () => {
         image_url: '',
         author: '1',
         created_at: '2026-04-10T14:23:15Z'
-      })
+      }),
+    deleteEvent: () => of(undefined)
   };
   const authServiceStub: {
     getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
@@ -47,6 +49,7 @@ describe('EventsComponent', () => {
         author: '1',
         created_at: '2026-04-10T14:23:15Z'
       });
+    eventServiceStub.deleteEvent = () => of(undefined);
     authServiceStub.getStoredUser = () => null;
     routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
@@ -438,6 +441,8 @@ describe('EventsComponent', () => {
   });
 
   it('should delete event when user confirms', () => {
+    const deleteEventSpy = vi.fn(() => of(undefined));
+    eventServiceStub.deleteEvent = deleteEventSpy;
     component.events = [
       {
         id: 2001,
@@ -456,11 +461,14 @@ describe('EventsComponent', () => {
     component.deleteEvent(2001);
 
     expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteEventSpy).toHaveBeenCalledWith(2001);
     expect(component.events.length).toBe(0);
     confirmSpy.mockRestore();
   });
 
   it('should keep event when user cancels delete confirmation', () => {
+    const deleteEventSpy = vi.fn(() => of(undefined));
+    eventServiceStub.deleteEvent = deleteEventSpy;
     component.events = [
       {
         id: 3001,
@@ -478,7 +486,38 @@ describe('EventsComponent', () => {
 
     component.deleteEvent(3001);
 
+    expect(deleteEventSpy).not.toHaveBeenCalled();
     expect(component.events.length).toBe(1);
+    confirmSpy.mockRestore();
+  });
+
+  it('should show delete error and keep event when API delete fails', () => {
+    eventServiceStub.deleteEvent = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 403
+          })
+      );
+    component.events = [
+      {
+        id: 3002,
+        name: 'Protected Event',
+        date: '22',
+        month: 'APR',
+        time: '8:00 PM',
+        location: 'Town Hall',
+        interested: 4,
+        imageUrl: 'https://example.com/protected.jpg',
+        createdByUser: true
+      }
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    component.deleteEvent(3002);
+
+    expect(component.events.length).toBe(1);
+    expect(component.deleteEventError).toBe('You can only delete events you created.');
     confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
 import { AuthService } from '../../services/auth.service';
-import { CommunityEvent, EventService } from '../../services/event.service';
+import { CommunityEvent, CreateEventPayload, EventService } from '../../services/event.service';
 
 describe('EventsComponent', () => {
   let component: EventsComponent;
@@ -13,8 +13,20 @@ describe('EventsComponent', () => {
   let routeQueryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
+    createEvent: (payload: CreateEventPayload) => Observable<CommunityEvent>;
   } = {
-    getEvents: () => of([])
+    getEvents: () => of([]),
+    createEvent: (payload: CreateEventPayload) =>
+      of({
+        id: 999,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      })
   };
   const authServiceStub: {
     getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
@@ -24,6 +36,17 @@ describe('EventsComponent', () => {
 
   beforeEach(async () => {
     eventServiceStub.getEvents = () => of([]);
+    eventServiceStub.createEvent = (payload: CreateEventPayload) =>
+      of({
+        id: 999,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      });
     authServiceStub.getStoredUser = () => null;
     routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
@@ -115,6 +138,22 @@ describe('EventsComponent', () => {
     expect(component.eventsError).toBe('Unable to reach the backend. Make sure the API is running.');
   });
 
+  it('should show loading state while events are being fetched', () => {
+    eventServiceStub.getEvents = () =>
+      new Observable<CommunityEvent[]>(() => {
+        return () => undefined;
+      });
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const loadingState = compiled.querySelector('.loading-state');
+    const hostCard = compiled.querySelector('.host-card');
+
+    expect(loadingState?.textContent).toContain('Loading events...');
+    expect(hostCard).toBeNull();
+  });
+
   it('should show only host card when there are no events', () => {
     fixture.detectChanges();
 
@@ -199,7 +238,47 @@ describe('EventsComponent', () => {
     expect(emptyNote).toBeNull();
   });
 
-  it('should not render past events from the API', () => {
+  it('should show all events in default view including user-created ones', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 2,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1,
+          title: 'My Event',
+          date: '2099-04-20',
+          time: '7:00 AM',
+          location: 'Riverside Park',
+          image_url: '/uploads/yoga.jpg',
+          author: '2',
+          created_at: '2026-04-10T14:23:15Z'
+        },
+        {
+          id: 2,
+          title: 'Other Event',
+          date: '2099-04-21',
+          time: '8:00 AM',
+          location: 'Depot Park',
+          image_url: '/uploads/other.jpg',
+          author: '3',
+          created_at: '2026-04-10T14:23:16Z'
+        }
+      ]);
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const eventCards = compiled.querySelectorAll('.event-card:not(.host-card)');
+
+    expect(component.displayedEvents.length).toBe(2);
+    expect(eventCards.length).toBe(2);
+  });
+
+  it('should keep past and upcoming events from the API', () => {
     eventServiceStub.getEvents = () =>
       of([
         {
@@ -226,8 +305,9 @@ describe('EventsComponent', () => {
 
     fixture.detectChanges();
 
-    expect(component.events.length).toBe(1);
-    expect(component.events[0].name).toBe('Upcoming Event');
+    expect(component.events.length).toBe(2);
+    expect(component.events[0].name).toBe('Old Event');
+    expect(component.events[1].name).toBe('Upcoming Event');
   });
 
   it('should keep form invalid when required fields are empty', () => {
@@ -241,12 +321,32 @@ describe('EventsComponent', () => {
     expect(form.checkValidity()).toBe(false);
   });
 
-  it('should create a user event and reset the form state', () => {
+  it('should create an event via API and reset form state', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    const createEventSpy = vi.fn((payload: CreateEventPayload) =>
+      of({
+        id: 4001,
+        title: payload.title,
+        date: payload.date,
+        time: payload.time,
+        location: payload.location,
+        image_url: '/uploads/new.jpg',
+        author: '1',
+        created_at: '2026-04-10T14:23:15Z'
+      })
+    );
+    eventServiceStub.createEvent = createEventSpy;
+
+    fixture.detectChanges();
     const initialEventCount = component.events.length;
     component.newEvent = {
       name: 'Neighborhood Cleanup',
-      date: '30',
-      month: 'APR',
+      date: '2026-04-30',
       time: '10:00 AM',
       location: 'Depot Park',
       interested: 0,
@@ -260,38 +360,75 @@ describe('EventsComponent', () => {
 
     component.createEvent(mockForm as never);
 
+    expect(createEventSpy).toHaveBeenCalledTimes(1);
     expect(component.events.length).toBe(initialEventCount + 1);
     expect(component.events[0].createdByUser).toBe(true);
+    expect(component.events[0].imageUrl).toBe('/uploads/new.jpg');
     expect(component.showCreateEventForm).toBe(false);
     expect(component.newEvent.name).toBe('');
   });
 
-  it('should show delete button only for user-created events', () => {
+  it('should show create error when API event creation fails', () => {
+    eventServiceStub.createEvent = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 401
+          })
+      );
+
     fixture.detectChanges();
-    component.events = [
-      {
-        id: 1001,
-        name: 'User Event',
-        date: '15',
-        month: 'APR',
-        time: '5:00 PM',
-        location: 'UF Campus',
-        interested: 10,
-        imageUrl: 'https://example.com/user-event.jpg',
-        createdByUser: true
-      },
-      {
-        id: 1002,
-        name: 'Community Event',
-        date: '16',
-        month: 'APR',
-        time: '6:00 PM',
-        location: 'Downtown',
-        interested: 20,
-        imageUrl: 'https://example.com/community-event.jpg',
-        createdByUser: false
-      }
-    ];
+    component.newEvent = {
+      name: 'Neighborhood Cleanup',
+      date: '2026-04-30',
+      time: '10:00 AM',
+      location: 'Depot Park',
+      interested: 0,
+      imageUrl: ''
+    };
+    const mockForm = {
+      invalid: false,
+      control: { markAllAsTouched: () => undefined },
+      resetForm: () => undefined
+    };
+
+    component.createEvent(mockForm as never);
+
+    expect(component.createEventError).toBe('You must be logged in to create an event.');
+    expect(component.showCreateEventForm).toBe(false);
+  });
+
+  it('should show delete button only for user-created events', () => {
+    authServiceStub.getStoredUser = () => ({
+      id: 1,
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      created_at: '2026-04-01T10:00:00Z'
+    });
+    eventServiceStub.getEvents = () =>
+      of([
+        {
+          id: 1001,
+          title: 'User Event',
+          date: '2099-04-15',
+          time: '5:00 PM',
+          location: 'UF Campus',
+          image_url: 'https://example.com/user-event.jpg',
+          author: '1',
+          created_at: '2026-04-10T14:23:15Z'
+        },
+        {
+          id: 1002,
+          title: 'Community Event',
+          date: '2099-04-16',
+          time: '6:00 PM',
+          location: 'Downtown',
+          image_url: 'https://example.com/community-event.jpg',
+          author: '2',
+          created_at: '2026-04-10T14:23:16Z'
+        }
+      ]);
+
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Observable, of, throwError } from 'rxjs';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { EventsComponent } from './events.component';
 import { AuthService } from '../../services/auth.service';
@@ -9,6 +10,7 @@ import { CommunityEvent, EventService } from '../../services/event.service';
 describe('EventsComponent', () => {
   let component: EventsComponent;
   let fixture: ComponentFixture<EventsComponent>;
+  let routeQueryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
   } = {
@@ -23,10 +25,17 @@ describe('EventsComponent', () => {
   beforeEach(async () => {
     eventServiceStub.getEvents = () => of([]);
     authServiceStub.getStoredUser = () => null;
+    routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
     await TestBed.configureTestingModule({
       imports: [EventsComponent],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: routeQueryParamMap$.asObservable()
+          }
+        },
         {
           provide: EventService,
           useValue: eventServiceStub
@@ -75,6 +84,17 @@ describe('EventsComponent', () => {
     expect(component.events[0].month).toBe('APR');
     expect(component.events[0].imageUrl).toBe('/uploads/1712345678_abc123.jpg');
     expect(component.events[0].createdByUser).toBe(true);
+  });
+
+  it('should refetch events when events refresh query param changes', () => {
+    const getEventsSpy = vi.fn(() => of([]));
+    eventServiceStub.getEvents = getEventsSpy;
+
+    fixture.detectChanges();
+    expect(getEventsSpy).toHaveBeenCalledTimes(1);
+
+    routeQueryParamMap$.next(convertToParamMap({ refresh: '1' }));
+    expect(getEventsSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should show error state when fetch fails', () => {

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -3,6 +3,10 @@ import { firstValueFrom, of } from 'rxjs';
 import { EventService } from './event.service';
 
 describe('EventService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('normalizes snake_case event payload fields', async () => {
     let requestedUrl = '';
     const httpClientStub = {
@@ -75,5 +79,116 @@ describe('EventService', () => {
       updated_at: '2026-05-01T13:35:00Z',
       deleted_at: null
     });
+  });
+
+  it('posts multipart event creation payload with auth token and normalizes response', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-123');
+
+    let postedUrl = '';
+    let postedTitle = '';
+    let postedDate = '';
+    let postedTime = '';
+    let postedLocation = '';
+    let postedImageName = '';
+    const postedHeaders: { Authorization?: string } = {};
+
+    const imageFile = new File(['image-content'], 'event.jpg', { type: 'image/jpeg' });
+    const httpClientStub = {
+      get: () => of([]),
+      post: (url: string, body: unknown, options?: { headers?: { get(name: string): string | null } }) => {
+        postedUrl = url;
+        if (body instanceof FormData) {
+          postedTitle = String(body.get('title') ?? '');
+          postedDate = String(body.get('date') ?? '');
+          postedTime = String(body.get('time') ?? '');
+          postedLocation = String(body.get('location') ?? '');
+          const image = body.get('image');
+          if (image instanceof File) {
+            postedImageName = image.name;
+          }
+        }
+        const auth = options?.headers?.get('Authorization');
+        if (auth) {
+          postedHeaders['Authorization'] = auth;
+        }
+        return of({
+          ID: 77,
+          Title: 'Neighborhood Cleanup',
+          Date: '2026-05-12',
+          Time: '10:00 AM',
+          Location: 'Depot Park',
+          ImageURL: '/uploads/new-event.jpg',
+          Author: '5',
+          CreatedAt: '2026-05-01T13:30:00Z',
+          UpdatedAt: '2026-05-01T13:30:00Z',
+          DeletedAt: null
+        });
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const created = await firstValueFrom(
+      service.createEvent({
+        title: 'Neighborhood Cleanup',
+        date: '2026-05-12',
+        time: '10:00 AM',
+        location: 'Depot Park',
+        image: imageFile
+      })
+    );
+
+    expect(postedUrl).toBe('/api/events');
+    expect(postedTitle).toBe('Neighborhood Cleanup');
+    expect(postedDate).toBe('2026-05-12');
+    expect(postedTime).toBe('10:00 AM');
+    expect(postedLocation).toBe('Depot Park');
+    expect(postedImageName).toBe('event.jpg');
+    expect(postedHeaders['Authorization']).toBe('Bearer jwt-token-123');
+    expect(created).toEqual({
+      id: 77,
+      title: 'Neighborhood Cleanup',
+      date: '2026-05-12',
+      time: '10:00 AM',
+      location: 'Depot Park',
+      image_url: '/uploads/new-event.jpg',
+      author: '5',
+      created_at: '2026-05-01T13:30:00Z',
+      updated_at: '2026-05-01T13:30:00Z',
+      deleted_at: null
+    });
+  });
+
+  it('normalizes relative upload paths to absolute /uploads paths', async () => {
+    const httpClientStub = {
+      get: () =>
+        of([
+          {
+            id: 5,
+            title: 'Movie Night',
+            date: '2026-06-02',
+            time: '8:00 PM',
+            location: 'Town Square',
+            image_url: 'uploads/movie-night.jpg',
+            author: 3,
+            created_at: '2026-06-01T10:00:00Z'
+          },
+          {
+            id: 6,
+            title: 'Picnic',
+            date: '2026-06-03',
+            time: '11:00 AM',
+            location: 'Lake Park',
+            image_url: './uploads/picnic.jpg',
+            author: 3,
+            created_at: '2026-06-01T11:00:00Z'
+          }
+        ])
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(events[0].image_url).toBe('/uploads/movie-night.jpg');
+    expect(events[1].image_url).toBe('/uploads/picnic.jpg');
   });
 });

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -191,4 +191,25 @@ describe('EventService', () => {
     expect(events[0].image_url).toBe('/uploads/movie-night.jpg');
     expect(events[1].image_url).toBe('/uploads/picnic.jpg');
   });
+
+  it('sends authenticated delete request for event deletion', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-123');
+
+    let deleteUrl = '';
+    let deleteAuthHeader = '';
+    const httpClientStub = {
+      get: () => of([]),
+      delete: (url: string, options?: { headers?: { get(name: string): string | null } }) => {
+        deleteUrl = url;
+        deleteAuthHeader = options?.headers?.get('Authorization') ?? '';
+        return of({ message: 'Event deleted successfully' });
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    await firstValueFrom(service.deleteEvent(101));
+
+    expect(deleteUrl).toBe('/api/events/101');
+    expect(deleteAuthHeader).toBe('Bearer jwt-token-123');
+  });
 });

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -1,0 +1,79 @@
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom, of } from 'rxjs';
+import { EventService } from './event.service';
+
+describe('EventService', () => {
+  it('normalizes snake_case event payload fields', async () => {
+    let requestedUrl = '';
+    const httpClientStub = {
+      get: (url: string) => {
+        requestedUrl = url;
+        return of([
+          {
+            id: 1,
+            title: ' Community BBQ ',
+            date: '2026-04-20',
+            time: '5:00 PM',
+            location: 'Central Park Pavilion',
+            image_url: '/uploads/example.jpg',
+            author: 7,
+            created_at: '2026-04-10T14:23:15Z'
+          }
+        ]);
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(requestedUrl).toBe('/api/events');
+    expect(events[0]).toEqual({
+      id: 1,
+      title: 'Community BBQ',
+      date: '2026-04-20',
+      time: '5:00 PM',
+      location: 'Central Park Pavilion',
+      image_url: '/uploads/example.jpg',
+      author: '7',
+      created_at: '2026-04-10T14:23:15Z',
+      updated_at: undefined,
+      deleted_at: null
+    });
+  });
+
+  it('normalizes PascalCase fields and fallback defaults', async () => {
+    const httpClientStub = {
+      get: () =>
+        of([
+          {
+            ID: 42,
+            Title: ' ',
+            Date: '2026-05-02',
+            Time: '9:00 AM',
+            Location: 'Depot Park',
+            ImageURL: '/uploads/depot.jpg',
+            Author: '9',
+            CreatedAt: '2026-05-01T13:30:00Z',
+            UpdatedAt: '2026-05-01T13:35:00Z',
+            DeletedAt: null
+          }
+        ])
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    const events = await firstValueFrom(service.getEvents());
+
+    expect(events[0]).toEqual({
+      id: 42,
+      title: 'Community Event',
+      date: '2026-05-02',
+      time: '9:00 AM',
+      location: 'Depot Park',
+      image_url: '/uploads/depot.jpg',
+      author: '9',
+      created_at: '2026-05-01T13:30:00Z',
+      updated_at: '2026-05-01T13:35:00Z',
+      deleted_at: null
+    });
+  });
+});

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiConfig } from '../config/api.config';
+
+interface RawEvent {
+  id?: number;
+  ID?: number;
+  title?: string;
+  Title?: string;
+  date?: string;
+  Date?: string;
+  time?: string;
+  Time?: string;
+  location?: string;
+  Location?: string;
+  image_url?: string;
+  imageUrl?: string;
+  ImageURL?: string;
+  author?: string | number;
+  Author?: string | number;
+  created_at?: string;
+  CreatedAt?: string;
+  updated_at?: string;
+  UpdatedAt?: string;
+  deleted_at?: string | null;
+  DeletedAt?: string | null;
+}
+
+export interface CommunityEvent {
+  id: number;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  image_url: string;
+  author: string;
+  created_at: string;
+  updated_at?: string;
+  deleted_at?: string | null;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventService {
+  private readonly apiUrl = `${ApiConfig.baseUrl}/events`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  private normalizeEvent(raw: RawEvent): CommunityEvent {
+    return {
+      id: raw.id ?? raw.ID ?? 0,
+      title: (raw.title ?? raw.Title ?? '').trim() || 'Community Event',
+      date: raw.date ?? raw.Date ?? '',
+      time: raw.time ?? raw.Time ?? '',
+      location: raw.location ?? raw.Location ?? '',
+      image_url: raw.image_url ?? raw.imageUrl ?? raw.ImageURL ?? '',
+      author: String(raw.author ?? raw.Author ?? ''),
+      created_at: raw.created_at ?? raw.CreatedAt ?? '',
+      updated_at: raw.updated_at ?? raw.UpdatedAt,
+      deleted_at: raw.deleted_at ?? raw.DeletedAt ?? null
+    };
+  }
+
+  getEvents(): Observable<CommunityEvent[]> {
+    return this.http
+      .get<RawEvent[]>(this.apiUrl)
+      .pipe(map((events) => events.map((event) => this.normalizeEvent(event))));
+  }
+}

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -119,4 +119,17 @@ export class EventService {
       .post<RawEvent>(this.apiUrl, formData, { headers })
       .pipe(map((event) => this.normalizeEvent(event)));
   }
+
+  deleteEvent(eventId: number): Observable<void> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http
+      .delete(`${this.apiUrl}/${eventId}`, { headers, observe: 'response', responseType: 'text' })
+      .pipe(map(() => undefined));
+  }
 }

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiConfig } from '../config/api.config';
 
@@ -40,22 +40,50 @@ export interface CommunityEvent {
   deleted_at?: string | null;
 }
 
+export interface CreateEventPayload {
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  image?: File | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class EventService {
   private readonly apiUrl = `${ApiConfig.baseUrl}/events`;
+  private readonly tokenKey = 'auth_token';
 
   constructor(private readonly http: HttpClient) {}
 
+  private normalizeImageUrl(rawImageUrl: string | undefined): string {
+    const value = (rawImageUrl ?? '').trim();
+    if (!value) {
+      return '';
+    }
+
+    if (/^https?:\/\//i.test(value) || value.startsWith('data:')) {
+      return value;
+    }
+
+    const normalizedPath = value.replaceAll('\\', '/').replace(/^\.?\//, '');
+    if (normalizedPath.startsWith('uploads/')) {
+      return `/${normalizedPath}`;
+    }
+
+    return value;
+  }
+
   private normalizeEvent(raw: RawEvent): CommunityEvent {
+    const rawImageUrl = raw.image_url ?? raw.imageUrl ?? raw.ImageURL;
     return {
       id: raw.id ?? raw.ID ?? 0,
       title: (raw.title ?? raw.Title ?? '').trim() || 'Community Event',
       date: raw.date ?? raw.Date ?? '',
       time: raw.time ?? raw.Time ?? '',
       location: raw.location ?? raw.Location ?? '',
-      image_url: raw.image_url ?? raw.imageUrl ?? raw.ImageURL ?? '',
+      image_url: this.normalizeImageUrl(rawImageUrl),
       author: String(raw.author ?? raw.Author ?? ''),
       created_at: raw.created_at ?? raw.CreatedAt ?? '',
       updated_at: raw.updated_at ?? raw.UpdatedAt,
@@ -65,7 +93,30 @@ export class EventService {
 
   getEvents(): Observable<CommunityEvent[]> {
     return this.http
-      .get<RawEvent[]>(this.apiUrl)
-      .pipe(map((events) => events.map((event) => this.normalizeEvent(event))));
+      .get<RawEvent[] | null>(this.apiUrl)
+      .pipe(map((events) => (events ?? []).map((event) => this.normalizeEvent(event))));
+  }
+
+  createEvent(payload: CreateEventPayload): Observable<CommunityEvent> {
+    const formData = new FormData();
+    formData.append('title', payload.title);
+    formData.append('date', payload.date);
+    formData.append('time', payload.time);
+    formData.append('location', payload.location);
+
+    if (payload.image) {
+      formData.append('image', payload.image);
+    }
+
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http
+      .post<RawEvent>(this.apiUrl, formData, { headers })
+      .pipe(map((event) => this.normalizeEvent(event)));
   }
 }

--- a/frontend/src/app/sidebar/sidebar.component.html
+++ b/frontend/src/app/sidebar/sidebar.component.html
@@ -22,6 +22,14 @@
 
     <a
             routerLink="/events"
+            [queryParams]="{ refresh: eventsRefreshToken }"
+            (click)="refreshEventsLink()"
+            [routerLinkActiveOptions]="{
+              paths: 'exact',
+              queryParams: 'ignored',
+              matrixParams: 'ignored',
+              fragment: 'ignored'
+            }"
             routerLinkActive="active"
             class="menu-item"
     >

--- a/frontend/src/app/sidebar/sidebar.component.ts
+++ b/frontend/src/app/sidebar/sidebar.component.ts
@@ -8,4 +8,10 @@ import { RouterModule } from '@angular/router';
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css'
 })
-export class SidebarComponent {}
+export class SidebarComponent {
+  eventsRefreshToken = 0;
+
+  refreshEventsLink(): void {
+    this.eventsRefreshToken += 1;
+  }
+}


### PR DESCRIPTION
## Summary
Integrated delete event functionality with backend API to allow users to remove events they created.

## Changes

- Connected delete action to `DELETE /api/events/:id` endpoint
- Added authentication token to request headers
- Displayed delete button only for events owned by the logged-in user
- Implemented confirmation dialog before deletion
- Removed event from UI after successful delete
- Added error handling for failed or unauthorized requests

## Behavior/Features

- Users can delete their own events
- Confirmation is required before deletion
- UI updates immediately after successful deletion
- Errors are handled and displayed appropriately

## Preview

<img width="1915" height="791" alt="Screenshot 2026-04-28 at 12 14 19 AM" src="https://github.com/user-attachments/assets/93247b33-540e-4976-9378-9f2714fc6f87" />


Closes #107 