### PR TITLE
97 fe build UI for edit event flow

### DIFF
--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -318,6 +318,21 @@
   background: #fecaca;
 }
 
+.edit-btn {
+  padding: 10px 14px;
+  border: none;
+  border-radius: 12px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.edit-btn:hover {
+  background: #bae6fd;
+}
+
 @media (max-width: 1024px) {
   .events-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -354,6 +354,21 @@
   background: #fecaca;
 }
 
+.edit-btn {
+  padding: 10px 14px;
+  border: none;
+  border-radius: 12px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.edit-btn:hover {
+  background: #bae6fd;
+}
+
 @media (max-width: 1024px) {
   .events-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -33,12 +33,12 @@
           <input
             type="text"
             placeholder="Event name"
-            [(ngModel)]="newEvent.name"
-            name="name"
-            #name="ngModel"
+            [(ngModel)]="newEvent.title"
+            name="title"
+            #title="ngModel"
             required
           />
-          <div *ngIf="name.invalid && (name.dirty || name.touched)" class="error-message">
+          <div *ngIf="title.invalid && (title.dirty || title.touched)" class="error-message">
             Event name is required.
           </div>
         </div>
@@ -137,8 +137,8 @@
           <input
             type="text"
             placeholder="Event name"
-            [(ngModel)]="editEventData.name"
-            name="name"
+            [(ngModel)]="editEventData.title"
+            name="title"
             #editName="ngModel"
             required
           />
@@ -284,7 +284,7 @@
       <div class="event-card" *ngFor="let event of displayedEvents">
 
         <div class="image-wrapper">
-          <img [src]="event.imageUrl" [alt]="event.name">
+          <img [src]="event.imageUrl" [alt]="event.title">
 
           <div class="date-badge">
             <span class="day">{{ event.date }}</span>
@@ -295,7 +295,7 @@
         </div>
 
         <div class="event-content">
-          <h3>{{ event.name }}</h3>
+          <h3>{{ event.title }}</h3>
           <p class="time">{{ event.time }}</p>
           <p class="location">{{ event.location }}</p>
           <p class="interested">{{ event.interested }} neighbors interested</p>

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -6,6 +6,10 @@
       <p>Discover what's happening in your community</p>
     </div>
 
+    <div *ngIf="deleteErrorMessage" class="error-message" style="color: red; margin-bottom: 20px;">
+      {{ deleteErrorMessage }}
+    </div>
+
     <div class="header-actions">
       <button
         class="create-event-btn"
@@ -115,6 +119,10 @@
         </div>
 
 
+        <div *ngIf="submitError" class="error-message" style="margin-bottom: 15px;">
+          {{ submitError }}
+        </div>
+
         <div class="modal-actions">
           <button type="button" (click)="closeCreateEvent()">Cancel</button>
           <button type="submit" [disabled]="eventForm.invalid || !!imageError">Create</button>
@@ -219,9 +227,13 @@
         </div>
 
 
+        <div *ngIf="editErrorMessage" class="error-message" style="margin-bottom: 15px;">
+          {{ editErrorMessage }}
+        </div>
+
         <div class="modal-actions">
           <button type="button" (click)="closeEditEvent()">Cancel</button>
-          <button type="submit" [disabled]="editForm.invalid || !!imageError">Save</button>
+          <button type="submit" [disabled]="editForm.invalid || !!imageError || isUpdatingEvent">Save</button>
         </div>
 
       </form>

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -15,7 +15,7 @@
       </button>
 
       <span class="your-events"
-                (click)="showOnlyUserEvents = !showOnlyUserEvents">
+            (click)="showOnlyUserEvents = !showOnlyUserEvents">
         {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
       </span>
     </div>
@@ -125,6 +125,110 @@
     </div>
   </div>
 
+  <!-- ✅ EDIT EVENT MODAL -->
+  <div class="event-modal-overlay" *ngIf="showEditEventForm">
+    <div class="event-modal">
+
+      <h2>Edit Event</h2>
+
+      <form (ngSubmit)="saveEditEvent(editForm)" #editForm="ngForm">
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Event name"
+            [(ngModel)]="editEventData.name"
+            name="name"
+            #editName="ngModel"
+            required
+          />
+          <div *ngIf="editName.invalid && (editName.dirty || editName.touched)" class="error-message">
+            Event name is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Date (e.g., 25)"
+            [(ngModel)]="editEventData.date"
+            name="date"
+            #editDate="ngModel"
+            required
+          />
+          <div *ngIf="editDate.invalid && (editDate.dirty || editDate.touched)" class="error-message">
+            Date is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Month (e.g., MAR)"
+            [(ngModel)]="editEventData.month"
+            name="month"
+            #editMonth="ngModel"
+            required
+          />
+          <div *ngIf="editMonth.invalid && (editMonth.dirty || editMonth.touched)" class="error-message">
+            Month is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Time (e.g., 5:00 PM)"
+            [(ngModel)]="editEventData.time"
+            name="time"
+            #editTime="ngModel"
+            required
+          />
+          <div *ngIf="editTime.invalid && (editTime.dirty || editTime.touched)" class="error-message">
+            Time is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Location"
+            [(ngModel)]="editEventData.location"
+            name="location"
+            #editLocation="ngModel"
+            required
+          />
+          <div *ngIf="editLocation.invalid && (editLocation.dirty || editLocation.touched)" class="error-message">
+            Location is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="file"
+            accept="image/*"
+            (change)="onEditImageUpload($event)"
+          />
+          <div *ngIf="imageError" class="error-message">
+            {{ imageError }}
+          </div>
+        </div>
+
+        <div *ngIf="imagePreview" class="image-preview">
+          <img [src]="imagePreview" alt="Preview" />
+        </div>
+
+
+        <div class="modal-actions">
+          <button type="button" (click)="closeEditEvent()">Cancel</button>
+          <button type="submit" [disabled]="editForm.invalid || !!imageError">Save</button>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
   <!-- EVENTS GRID -->
   <!--<div class="events-grid">
   <div class="event-card" *ngFor="let event of displayedEvents">
@@ -198,6 +302,14 @@
 
           <div class="event-actions">
             <button class="interest-btn">+ Interested?</button>
+
+            <button
+              *ngIf="event.createdByUser"
+              type="button"
+              class="edit-btn"
+              (click)="openEditEvent(event)">
+              Edit
+            </button>
 
             <button
               *ngIf="event.createdByUser"

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -14,7 +14,7 @@
       </button>
 
       <span class="your-events"
-                (click)="showOnlyUserEvents = !showOnlyUserEvents">
+            (click)="showOnlyUserEvents = !showOnlyUserEvents">
         {{ showOnlyUserEvents ? 'All events' : 'Your events' }}
       </span>
     </div>
@@ -114,6 +114,110 @@
     </div>
   </div>
 
+  <!-- ✅ EDIT EVENT MODAL -->
+  <div class="event-modal-overlay" *ngIf="showEditEventForm">
+    <div class="event-modal">
+
+      <h2>Edit Event</h2>
+
+      <form (ngSubmit)="saveEditEvent(editForm)" #editForm="ngForm">
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Event name"
+            [(ngModel)]="editEventData.name"
+            name="name"
+            #editName="ngModel"
+            required
+          />
+          <div *ngIf="editName.invalid && (editName.dirty || editName.touched)" class="error-message">
+            Event name is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Date (e.g., 25)"
+            [(ngModel)]="editEventData.date"
+            name="date"
+            #editDate="ngModel"
+            required
+          />
+          <div *ngIf="editDate.invalid && (editDate.dirty || editDate.touched)" class="error-message">
+            Date is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Month (e.g., MAR)"
+            [(ngModel)]="editEventData.month"
+            name="month"
+            #editMonth="ngModel"
+            required
+          />
+          <div *ngIf="editMonth.invalid && (editMonth.dirty || editMonth.touched)" class="error-message">
+            Month is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Time (e.g., 5:00 PM)"
+            [(ngModel)]="editEventData.time"
+            name="time"
+            #editTime="ngModel"
+            required
+          />
+          <div *ngIf="editTime.invalid && (editTime.dirty || editTime.touched)" class="error-message">
+            Time is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="text"
+            placeholder="Location"
+            [(ngModel)]="editEventData.location"
+            name="location"
+            #editLocation="ngModel"
+            required
+          />
+          <div *ngIf="editLocation.invalid && (editLocation.dirty || editLocation.touched)" class="error-message">
+            Location is required.
+          </div>
+        </div>
+
+        <div class="form-group">
+          <input
+            type="file"
+            accept="image/*"
+            (change)="onEditImageUpload($event)"
+          />
+          <div *ngIf="imageError" class="error-message">
+            {{ imageError }}
+          </div>
+        </div>
+
+        <div *ngIf="imagePreview" class="image-preview">
+          <img [src]="imagePreview" alt="Preview" />
+        </div>
+
+
+        <div class="modal-actions">
+          <button type="button" (click)="closeEditEvent()">Cancel</button>
+          <button type="submit" [disabled]="editForm.invalid || !!imageError">Save</button>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
   <!-- EVENTS GRID -->
   <!--<div class="events-grid">
   <div class="event-card" *ngFor="let event of displayedEvents">
@@ -200,6 +304,14 @@
 
           <div class="event-actions">
             <button class="interest-btn">+ Interested?</button>
+
+            <button
+              *ngIf="event.createdByUser"
+              type="button"
+              class="edit-btn"
+              (click)="openEditEvent(event)">
+              Edit
+            </button>
 
             <button
               *ngIf="event.createdByUser"

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -6,6 +6,10 @@
       <p>Discover what's happening in your community</p>
     </div>
 
+    <div *ngIf="deleteErrorMessage" class="error-message" style="color: red; margin-bottom: 20px;">
+      {{ deleteErrorMessage }}
+    </div>
+
     <div class="header-actions">
       <button
         class="create-event-btn"
@@ -100,6 +104,10 @@
 
         <div *ngIf="createEventError" class="error-message">
           {{ createEventError }}
+        </div>
+
+        <div *ngIf="submitError" class="error-message" style="margin-bottom: 15px;">
+          {{ submitError }}
         </div>
 
         <div class="modal-actions">
@@ -208,9 +216,13 @@
         </div>
 
 
+        <div *ngIf="editErrorMessage" class="error-message" style="margin-bottom: 15px;">
+          {{ editErrorMessage }}
+        </div>
+
         <div class="modal-actions">
           <button type="button" (click)="closeEditEvent()">Cancel</button>
-          <button type="submit" [disabled]="editForm.invalid || !!imageError">Save</button>
+          <button type="submit" [disabled]="editForm.invalid || !!imageError || isUpdatingEvent">Save</button>
         </div>
 
       </form>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -23,12 +23,24 @@ interface EventItem {
 })
 export class EventsComponent {
   showCreateEventForm = false;
+  showEditEventForm = false;
+  editingEventId: number | null = null;
   showOnlyUserEvents = false;
 
   imagePreview: string | null = null;
   imageError = '';
 
   newEvent = {
+    name: '',
+    date: '',
+    month: '',
+    time: '',
+    location: '',
+    interested: 0,
+    imageUrl: ''
+  };
+
+  editEventData = {
     name: '',
     date: '',
     month: '',
@@ -104,6 +116,64 @@ export class EventsComponent {
     }
 
     return this.events;
+  }
+
+  openEditEvent(event: EventItem): void {
+    this.editingEventId = event.id;
+    this.editEventData = { ...event };
+    this.showEditEventForm = true;
+    this.imageError = '';
+    this.imagePreview = event.imageUrl || null;
+  }
+
+  closeEditEvent(): void {
+    this.showEditEventForm = false;
+    this.editingEventId = null;
+    this.resetForm();
+  }
+
+  onEditImageUpload(event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    if (!input.files || input.files.length === 0) {
+      this.imageError = '';
+      return;
+    }
+
+    const file = input.files[0];
+
+    if (!file.type.startsWith('image/')) {
+      this.imageError = 'Please upload a valid image file.';
+      this.imagePreview = null;
+      this.editEventData.imageUrl = '';
+      return;
+    }
+
+    this.imageError = '';
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      this.imagePreview = reader.result as string;
+      this.editEventData.imageUrl = this.imagePreview;
+    };
+
+    reader.readAsDataURL(file);
+  }
+
+  saveEditEvent(editForm: NgForm): void {
+    if (editForm.invalid || this.imageError || !this.editingEventId) {
+      editForm.control.markAllAsTouched();
+      return;
+    }
+
+    this.events = this.events.map((e) => 
+      e.id === this.editingEventId 
+        ? { ...e, ...this.editEventData }
+        : e
+    );
+
+    this.closeEditEvent();
   }
 
   openCreateEvent(): void {

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -177,7 +177,7 @@ export class EventsComponent implements OnInit {
       return;
     }
 
-    this.imageFile = file;
+    this.editImageFile = file;
 
     const reader = new FileReader();
 
@@ -190,18 +190,36 @@ export class EventsComponent implements OnInit {
   }
 
   saveEditEvent(editForm: NgForm): void {
-    if (editForm.invalid || this.imageError || !this.editingEventId) {
+    if (editForm.invalid || this.imageError || !this.editingEventId || this.isUpdatingEvent) {
       editForm.control.markAllAsTouched();
       return;
     }
 
-    this.events = this.events.map((e) => 
-      e.id === this.editingEventId 
-        ? { ...e, ...this.editEventData }
-        : e
-    );
+    this.isUpdatingEvent = true;
+    this.editErrorMessage = '';
 
-    this.closeEditEvent();
+    this.eventService.updateEvent({
+      id: this.editingEventId,
+      title: this.editEventData.title || '',
+      date: this.editEventData.date || '',
+      month: this.editEventData.month || '',
+      time: this.editEventData.time || '',
+      location: this.editEventData.location || '',
+      image: this.editImageFile || undefined
+    }).pipe(finalize(() => {
+      this.isUpdatingEvent = false;
+      this.cdr.detectChanges();
+    })).subscribe({
+      next: (updatedEvent) => {
+        updatedEvent.createdByUser = true;
+        this.events = this.events.map(e => e.id === this.editingEventId ? updatedEvent : e);
+        this.closeEditEvent();
+      },
+      error: (err) => {
+        console.error('Update failed', err);
+        this.editErrorMessage = 'Server failed to update event.';
+      }
+    });
   }
 
   openCreateEvent(): void {
@@ -266,13 +284,14 @@ export class EventsComponent implements OnInit {
       next: (createdEvent) => {
         createdEvent.createdByUser = true;
         this.events = [createdEvent, ...this.events];
-        
+
         this.resetForm();
         eventForm.resetForm();
         this.showCreateEventForm = false;
       },
       error: (err) => {
         console.error('Failed to create event:', err);
+        this.submitError = 'Server failed to save event. Database check needed.';
       }
     });
   }
@@ -290,5 +309,6 @@ export class EventsComponent implements OnInit {
     this.imagePreview = null;
     this.imageFile = null;
     this.imageError = '';
+    this.submitError = '';
   }
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -1,18 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, NgForm } from '@angular/forms';
-
-interface EventItem {
-  id: number;
-  name: string;
-  date: string;
-  month: string;
-  time: string;
-  location: string;
-  interested: number;
-  imageUrl: string;
-  createdByUser?: boolean;
-}
+import { EventService, EventItem } from '../../services/event.service';
+import { AuthService } from '../../services/auth.service';
+import { finalize } from 'rxjs';
 
 @Component({
   selector: 'app-events',
@@ -21,17 +12,54 @@ interface EventItem {
   templateUrl: './events.component.html',
   styleUrl: './events.component.css'
 })
-export class EventsComponent {
+export class EventsComponent implements OnInit {
   showCreateEventForm = false;
   showEditEventForm = false;
   editingEventId: number | null = null;
   showOnlyUserEvents = false;
+  isLoading = false;
+  isSubmitting = false;
+
+  currentUserId = '';
+
+  constructor(
+    private readonly eventService: EventService,
+    private readonly authService: AuthService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    const user = this.authService.getStoredUser();
+    if (user) {
+      this.currentUserId = `${user.id}`;
+    }
+    this.fetchEvents();
+  }
+
+  fetchEvents(): void {
+    this.isLoading = true;
+    this.eventService.getEvents()
+      .pipe(finalize(() => {
+        this.isLoading = false;
+        this.cdr.detectChanges();
+      }))
+      .subscribe({
+        next: (data) => {
+          this.events = data.map(event => ({
+            ...event,
+            createdByUser: event.author === this.currentUserId
+          }));
+        },
+        error: (err) => console.error('Failed to load events:', err)
+      });
+  }
 
   imagePreview: string | null = null;
+  imageFile: File | null = null;
   imageError = '';
 
   newEvent = {
-    name: '',
+    title: '',
     date: '',
     month: '',
     time: '',
@@ -40,8 +68,8 @@ export class EventsComponent {
     imageUrl: ''
   };
 
-  editEventData = {
-    name: '',
+  editEventData: Partial<EventItem> = {
+    title: '',
     date: '',
     month: '',
     time: '',
@@ -149,7 +177,7 @@ export class EventsComponent {
       return;
     }
 
-    this.imageError = '';
+    this.imageFile = file;
 
     const reader = new FileReader();
 
@@ -203,7 +231,7 @@ export class EventsComponent {
       return;
     }
 
-    this.imageError = '';
+    this.imageFile = file;
 
     const reader = new FileReader();
 
@@ -216,27 +244,42 @@ export class EventsComponent {
   }
 
   createEvent(eventForm: NgForm): void {
-    if (eventForm.invalid || this.imageError) {
+    if (eventForm.invalid || this.imageError || this.isSubmitting) {
       eventForm.control.markAllAsTouched();
       return;
     }
 
-    const newEventWithId: EventItem = {
-      id: Date.now(),
-      ...this.newEvent,
-      createdByUser: true
-    };
-
-    this.events = [newEventWithId, ...this.events];
-
-    this.resetForm();
-    eventForm.resetForm();
-    this.showCreateEventForm = false;
+    this.isSubmitting = true;
+    this.eventService.createEvent({
+      title: this.newEvent.title,
+      date: this.newEvent.date,
+      month: this.newEvent.month,
+      time: this.newEvent.time,
+      location: this.newEvent.location,
+      image: this.imageFile || undefined
+    })
+    .pipe(finalize(() => {
+      this.isSubmitting = false;
+      this.cdr.detectChanges();
+    }))
+    .subscribe({
+      next: (createdEvent) => {
+        createdEvent.createdByUser = true;
+        this.events = [createdEvent, ...this.events];
+        
+        this.resetForm();
+        eventForm.resetForm();
+        this.showCreateEventForm = false;
+      },
+      error: (err) => {
+        console.error('Failed to create event:', err);
+      }
+    });
   }
 
   private resetForm(): void {
     this.newEvent = {
-      name: '',
+      title: '',
       date: '',
       month: '',
       time: '',
@@ -245,6 +288,7 @@ export class EventsComponent {
       imageUrl: ''
     };
     this.imagePreview = null;
+    this.imageFile = null;
     this.imageError = '';
   }
 }

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -182,8 +182,8 @@ export class EventsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.events = this.events.map((e) => 
-      e.id === this.editingEventId 
+    this.events = this.events.map((e) =>
+      e.id === this.editingEventId
         ? { ...e, ...this.editEventData }
         : e
     );

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -29,6 +29,8 @@ interface EventItem {
 })
 export class EventsComponent implements OnInit, OnDestroy {
   showCreateEventForm = false;
+  showEditEventForm = false;
+  editingEventId: number | null = null;
   showOnlyUserEvents = false;
   isLoadingEvents = false;
   eventsError = '';
@@ -68,6 +70,16 @@ export class EventsComponent implements OnInit, OnDestroy {
   newEvent = {
     name: '',
     date: '',
+    time: '',
+    location: '',
+    interested: 0,
+    imageUrl: ''
+  };
+
+  editEventData = {
+    name: '',
+    date: '',
+    month: '',
     time: '',
     location: '',
     interested: 0,
@@ -119,6 +131,64 @@ export class EventsComponent implements OnInit, OnDestroy {
     }
 
     return this.events;
+  }
+
+  openEditEvent(event: EventItem): void {
+    this.editingEventId = event.id;
+    this.editEventData = { ...event };
+    this.showEditEventForm = true;
+    this.imageError = '';
+    this.imagePreview = event.imageUrl || null;
+  }
+
+  closeEditEvent(): void {
+    this.showEditEventForm = false;
+    this.editingEventId = null;
+    this.resetForm();
+  }
+
+  onEditImageUpload(event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    if (!input.files || input.files.length === 0) {
+      this.imageError = '';
+      return;
+    }
+
+    const file = input.files[0];
+
+    if (!file.type.startsWith('image/')) {
+      this.imageError = 'Please upload a valid image file.';
+      this.imagePreview = null;
+      this.editEventData.imageUrl = '';
+      return;
+    }
+
+    this.imageError = '';
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      this.imagePreview = reader.result as string;
+      this.editEventData.imageUrl = this.imagePreview;
+    };
+
+    reader.readAsDataURL(file);
+  }
+
+  saveEditEvent(editForm: NgForm): void {
+    if (editForm.invalid || this.imageError || !this.editingEventId) {
+      editForm.control.markAllAsTouched();
+      return;
+    }
+
+    this.events = this.events.map((e) => 
+      e.id === this.editingEventId 
+        ? { ...e, ...this.editEventData }
+        : e
+    );
+
+    this.closeEditEvent();
   }
 
   openCreateEvent(): void {

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -67,17 +67,22 @@ export class EventsComponent implements OnInit, OnDestroy {
     this.refreshSubscription?.unsubscribe();
   }
 
+  imagePreview: string | null = null;
+  imageFile: File | null = null;
+  imageError = '';
+
   newEvent = {
-    name: '',
+    title: '',
     date: '',
+    month: '',
     time: '',
     location: '',
     interested: 0,
     imageUrl: ''
   };
 
-  editEventData = {
-    name: '',
+  editEventData: Partial<EventItem> = {
+    title: '',
     date: '',
     month: '',
     time: '',

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiConfig } from '../config/api.config';
+
+export interface EventItem {
+  id: number;
+  title: string;
+  date: string;
+  month: string;
+  time: string;
+  location: string;
+  interested: number;
+  imageUrl: string;
+  author: string;
+  createdByUser?: boolean;
+}
+
+export interface CreateEventPayload {
+  title: string;
+  date: string;
+  month: string;
+  time: string;
+  location: string;
+  image?: File;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventService {
+  private readonly apiUrl = `${ApiConfig.baseUrl}/events`;
+  private readonly tokenKey = 'auth_token';
+
+  constructor(private readonly http: HttpClient) {}
+
+  private extractDate(dateStr: string): string {
+    if (dateStr.includes('|')) return dateStr.split('|')[0];
+    return dateStr;
+  }
+
+  private extractMonth(dateStr: string): string {
+    if (dateStr.includes('|')) return dateStr.split('|')[1];
+    return '';
+  }
+
+  getEvents(): Observable<EventItem[]> {
+    return this.http.get<any[]>(this.apiUrl).pipe(
+      map(events => events.map(e => ({
+        id: e.ID,
+        title: e.title,
+        date: this.extractDate(e.date),
+        month: this.extractMonth(e.date),
+        time: e.time,
+        location: e.location,
+        interested: 0,
+        imageUrl: e.image_url ? `${ApiConfig.baseUrl.replace('/api', '')}${e.image_url}` : '',
+        author: e.author || ''
+      })))
+    );
+  }
+
+  createEvent(payload: CreateEventPayload): Observable<EventItem> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token ? new HttpHeaders({ Authorization: `Bearer ${token}` }) : undefined;
+    
+    const formData = new FormData();
+    formData.append('title', payload.title);
+    
+    // We pack date and month into the date field since the backend schema lacks a separate month string
+    formData.append('date', `${payload.date}|${payload.month}`);
+    
+    formData.append('time', payload.time);
+    formData.append('location', payload.location);
+    if (payload.image) {
+      formData.append('image', payload.image);
+    }
+    
+    return this.http.post<any>(this.apiUrl, formData, { headers }).pipe(
+      map(e => ({
+        id: e.ID,
+        title: e.title,
+        date: this.extractDate(e.date),
+        month: this.extractMonth(e.date),
+        time: e.time,
+        location: e.location,
+        interested: 0,
+        imageUrl: e.image_url ? `${ApiConfig.baseUrl.replace('/api', '')}${e.image_url}` : '',
+        author: e.author || ''
+      }))
+    );
+  }
+}

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -25,6 +25,16 @@ export interface CreateEventPayload {
   image?: File;
 }
 
+export interface UpdateEventPayload {
+  id: number;
+  title?: string;
+  date?: string;
+  month?: string;
+  time?: string;
+  location?: string;
+  image?: File;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -89,5 +99,40 @@ export class EventService {
         author: e.author || ''
       }))
     );
+  }
+
+  updateEvent(payload: UpdateEventPayload): Observable<EventItem> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token ? new HttpHeaders({ Authorization: `Bearer ${token}` }) : undefined;
+    
+    const formData = new FormData();
+    formData.append('id', payload.id.toString());
+    if (payload.title) formData.append('title', payload.title);
+    if (payload.date || payload.month) {
+      formData.append('date', `${payload.date || ''}|${payload.month || ''}`);
+    }
+    if (payload.time) formData.append('time', payload.time);
+    if (payload.location) formData.append('location', payload.location);
+    if (payload.image) formData.append('image', payload.image);
+    
+    return this.http.post<any>(`${this.apiUrl}/update`, formData, { headers }).pipe(
+      map(e => ({
+        id: e.ID,
+        title: e.title,
+        date: this.extractDate(e.date),
+        month: this.extractMonth(e.date),
+        time: e.time,
+        location: e.location,
+        interested: 0,
+        imageUrl: e.image_url ? `${ApiConfig.baseUrl.replace('/api', '')}${e.image_url}` : '',
+        author: e.author || ''
+      }))
+    );
+  }
+
+  deleteEvent(id: number): Observable<{ message: string }> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token ? new HttpHeaders({ Authorization: `Bearer ${token}` }) : undefined;
+    return this.http.post<{ message: string }>(`${this.apiUrl}/delete`, { id }, { headers });
   }
 }

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -48,6 +48,16 @@ export interface CreateEventPayload {
   image?: File | null;
 }
 
+export interface UpdateEventPayload {
+  id: number;
+  title?: string;
+  date?: string;
+  month?: string;
+  time?: string;
+  location?: string;
+  image?: File;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -118,5 +128,40 @@ export class EventService {
     return this.http
       .post<RawEvent>(this.apiUrl, formData, { headers })
       .pipe(map((event) => this.normalizeEvent(event)));
+  }
+
+  updateEvent(payload: UpdateEventPayload): Observable<EventItem> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token ? new HttpHeaders({ Authorization: `Bearer ${token}` }) : undefined;
+    
+    const formData = new FormData();
+    formData.append('id', payload.id.toString());
+    if (payload.title) formData.append('title', payload.title);
+    if (payload.date || payload.month) {
+      formData.append('date', `${payload.date || ''}|${payload.month || ''}`);
+    }
+    if (payload.time) formData.append('time', payload.time);
+    if (payload.location) formData.append('location', payload.location);
+    if (payload.image) formData.append('image', payload.image);
+    
+    return this.http.post<any>(`${this.apiUrl}/update`, formData, { headers }).pipe(
+      map(e => ({
+        id: e.ID,
+        title: e.title,
+        date: this.extractDate(e.date),
+        month: this.extractMonth(e.date),
+        time: e.time,
+        location: e.location,
+        interested: 0,
+        imageUrl: e.image_url ? `${ApiConfig.baseUrl.replace('/api', '')}${e.image_url}` : '',
+        author: e.author || ''
+      }))
+    );
+  }
+
+  deleteEvent(id: number): Observable<{ message: string }> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token ? new HttpHeaders({ Authorization: `Bearer ${token}` }) : undefined;
+    return this.http.post<{ message: string }>(`${this.apiUrl}/delete`, { id }, { headers });
   }
 }


### PR DESCRIPTION

### Description
This PR implements the frontend UI and service integration for the **Edit Event** flow. It allows users to modify their existing events via a dedicated modal, supporting title, date, time, location, and image updates.

### Verification
- [x] Verified edit modal opens with pre-populated data.
- [x] Successfully updated event details and images via the backend API.
- [x] Confirmed the UI correctly reflects updates without a full page refresh.

<img width="1708" height="1004" alt="Screenshot 2026-04-28 at 4 25 31 PM" src="https://github.com/user-attachments/assets/8551753b-5d2c-433d-8d88-8977b320c147" />
<img width="1699" height="955" alt="Screenshot 2026-04-28 at 4 26 39 PM" src="https://github.com/user-attachments/assets/3d2ae3e1-025f-4b40-912e-9c652ac83b09" />
<img width="1699" height="972" alt="Screenshot 2026-04-28 at 4 27 11 PM" src="https://github.com/user-attachments/assets/17dfe41c-a3af-40df-bb6a-b2a79e2b07da" />
<img width="1701" height="992" alt="Screenshot 2026-04-28 at 4 28 11 PM" src="https://github.com/user-attachments/assets/73f20766-4e87-4581-9a26-ff43c260e673" />
<img width="1691" height="989" alt="Screenshot 2026-04-28 at 4 37 25 PM" src="https://github.com/user-attachments/assets/9839d6b2-15ab-4527-9ad4-d9d3cd4d34d8" />


