### PR TITLE
Delete event connected to backend DELETE api

### DIFF
--- a/frontend/src/app/pages/events/events.component.css
+++ b/frontend/src/app/pages/events/events.component.css
@@ -52,6 +52,12 @@
   font-size: 14px;
 }
 
+.events-delete-error {
+  margin: 0 0 14px;
+  color: #b91c1c;
+  font-size: 14px;
+}
+
 .status-state {
   background: #ffffff;
   border: 1px solid #e5e7eb;
@@ -352,6 +358,11 @@
 
 .delete-btn:hover {
   background: #fecaca;
+}
+
+.delete-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/app/pages/events/events.component.html
+++ b/frontend/src/app/pages/events/events.component.html
@@ -172,6 +172,10 @@
 
   <!-- EVENTS GRID -->
   <div *ngIf="!isLoadingEvents && !eventsError">
+    <div class="events-delete-error" *ngIf="deleteEventError">
+      {{ deleteEventError }}
+    </div>
+
     <div class="events-empty-note" *ngIf="displayedEvents.length === 0">
       {{ showOnlyUserEvents ? 'No events created yet' : 'No events available' }}
     </div>
@@ -205,8 +209,9 @@
               *ngIf="event.createdByUser"
               type="button"
               class="delete-btn"
+              [disabled]="deletingEventIds.has(event.id)"
               (click)="deleteEvent(event.id)">
-              Delete
+              {{ deletingEventIds.has(event.id) ? 'Deleting...' : 'Delete' }}
             </button>
           </div>
         </div>

--- a/frontend/src/app/pages/events/events.component.ts
+++ b/frontend/src/app/pages/events/events.component.ts
@@ -37,7 +37,9 @@ export class EventsComponent implements OnInit, OnDestroy {
   selectedImageFile: File | null = null;
   imageError = '';
   createEventError = '';
+  deleteEventError = '';
   isCreatingEvent = false;
+  deletingEventIds = new Set<number>();
   private currentUserId = '';
   private refreshSubscription?: Subscription;
   private readonly monthLabels = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
@@ -75,19 +77,43 @@ export class EventsComponent implements OnInit, OnDestroy {
   };
 
   deleteEvent(id: number): void {
-    const confirmDelete = confirm('Are you sure you want to delete this event?');
+    if (this.deletingEventIds.has(id)) {
+      return;
+    }
+
+    const confirmDelete = window.confirm('Are you sure you want to delete this event?');
 
     if (!confirmDelete) {
       return;
     }
 
-    this.events = this.events.filter(event => event.id !== id);
+    this.deleteEventError = '';
+    this.deletingEventIds = new Set(this.deletingEventIds).add(id);
+
+    this.eventService
+      .deleteEvent(id)
+      .pipe(finalize(() => {
+        const nextDeletingIds = new Set(this.deletingEventIds);
+        nextDeletingIds.delete(id);
+        this.deletingEventIds = nextDeletingIds;
+        this.cdr.detectChanges();
+      }))
+      .subscribe({
+        next: () => {
+          this.events = this.events.filter(event => String(event.id) !== String(id));
+        },
+        error: (error: unknown) => {
+          console.error(error);
+          this.deleteEventError = this.getDeleteErrorMessage(error);
+        }
+      });
   }
   events: EventItem[] = [];
 
   fetchEvents(): void {
     this.isLoadingEvents = true;
     this.eventsError = '';
+    this.deleteEventError = '';
 
     this.eventService
       .getEvents()
@@ -125,6 +151,7 @@ export class EventsComponent implements OnInit, OnDestroy {
     this.showCreateEventForm = true;
     this.imageError = '';
     this.createEventError = '';
+    this.deleteEventError = '';
   }
 
   closeCreateEvent(): void {
@@ -319,6 +346,37 @@ export class EventsComponent implements OnInit, OnDestroy {
     }
 
     return 'Failed to create event. Please try again.';
+  }
+
+  private getDeleteErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to delete event. Please try again.';
+    }
+
+    if (error.status === 401) {
+      return 'You must be logged in to delete this event.';
+    }
+
+    if (error.status === 403) {
+      return 'You can only delete events you created.';
+    }
+
+    if (error.status === 0) {
+      return 'Unable to reach the backend. Make sure the API is running.';
+    }
+
+    if (typeof error.error === 'string') {
+      const trimmed = error.error.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (error.error?.error) {
+      return error.error.error;
+    }
+
+    return 'Failed to delete event. Please try again.';
   }
 
 }

--- a/frontend/src/app/pages/events/events.spec.ts
+++ b/frontend/src/app/pages/events/events.spec.ts
@@ -14,6 +14,7 @@ describe('EventsComponent', () => {
   const eventServiceStub: {
     getEvents: () => Observable<CommunityEvent[]>;
     createEvent: (payload: CreateEventPayload) => Observable<CommunityEvent>;
+    deleteEvent: (id: number) => Observable<void>;
   } = {
     getEvents: () => of([]),
     createEvent: (payload: CreateEventPayload) =>
@@ -26,7 +27,8 @@ describe('EventsComponent', () => {
         image_url: '',
         author: '1',
         created_at: '2026-04-10T14:23:15Z'
-      })
+      }),
+    deleteEvent: () => of(undefined)
   };
   const authServiceStub: {
     getStoredUser: () => { id: number; name: string; email: string; created_at: string } | null;
@@ -47,6 +49,7 @@ describe('EventsComponent', () => {
         author: '1',
         created_at: '2026-04-10T14:23:15Z'
       });
+    eventServiceStub.deleteEvent = () => of(undefined);
     authServiceStub.getStoredUser = () => null;
     routeQueryParamMap$ = new BehaviorSubject(convertToParamMap({ refresh: '0' }));
 
@@ -438,6 +441,8 @@ describe('EventsComponent', () => {
   });
 
   it('should delete event when user confirms', () => {
+    const deleteEventSpy = vi.fn(() => of(undefined));
+    eventServiceStub.deleteEvent = deleteEventSpy;
     component.events = [
       {
         id: 2001,
@@ -456,11 +461,14 @@ describe('EventsComponent', () => {
     component.deleteEvent(2001);
 
     expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteEventSpy).toHaveBeenCalledWith(2001);
     expect(component.events.length).toBe(0);
     confirmSpy.mockRestore();
   });
 
   it('should keep event when user cancels delete confirmation', () => {
+    const deleteEventSpy = vi.fn(() => of(undefined));
+    eventServiceStub.deleteEvent = deleteEventSpy;
     component.events = [
       {
         id: 3001,
@@ -478,7 +486,38 @@ describe('EventsComponent', () => {
 
     component.deleteEvent(3001);
 
+    expect(deleteEventSpy).not.toHaveBeenCalled();
     expect(component.events.length).toBe(1);
+    confirmSpy.mockRestore();
+  });
+
+  it('should show delete error and keep event when API delete fails', () => {
+    eventServiceStub.deleteEvent = () =>
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 403
+          })
+      );
+    component.events = [
+      {
+        id: 3002,
+        name: 'Protected Event',
+        date: '22',
+        month: 'APR',
+        time: '8:00 PM',
+        location: 'Town Hall',
+        interested: 4,
+        imageUrl: 'https://example.com/protected.jpg',
+        createdByUser: true
+      }
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    component.deleteEvent(3002);
+
+    expect(component.events.length).toBe(1);
+    expect(component.deleteEventError).toBe('You can only delete events you created.');
     confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/app/services/event.service.spec.ts
+++ b/frontend/src/app/services/event.service.spec.ts
@@ -191,4 +191,25 @@ describe('EventService', () => {
     expect(events[0].image_url).toBe('/uploads/movie-night.jpg');
     expect(events[1].image_url).toBe('/uploads/picnic.jpg');
   });
+
+  it('sends authenticated delete request for event deletion', async () => {
+    localStorage.setItem('auth_token', 'jwt-token-123');
+
+    let deleteUrl = '';
+    let deleteAuthHeader = '';
+    const httpClientStub = {
+      get: () => of([]),
+      delete: (url: string, options?: { headers?: { get(name: string): string | null } }) => {
+        deleteUrl = url;
+        deleteAuthHeader = options?.headers?.get('Authorization') ?? '';
+        return of({ message: 'Event deleted successfully' });
+      }
+    } as unknown as HttpClient;
+
+    const service = new EventService(httpClientStub);
+    await firstValueFrom(service.deleteEvent(101));
+
+    expect(deleteUrl).toBe('/api/events/101');
+    expect(deleteAuthHeader).toBe('Bearer jwt-token-123');
+  });
 });

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -119,4 +119,17 @@ export class EventService {
       .post<RawEvent>(this.apiUrl, formData, { headers })
       .pipe(map((event) => this.normalizeEvent(event)));
   }
+
+  deleteEvent(eventId: number): Observable<void> {
+    const token = localStorage.getItem(this.tokenKey);
+    const headers = token
+      ? new HttpHeaders({
+          Authorization: `Bearer ${token}`
+        })
+      : undefined;
+
+    return this.http
+      .delete(`${this.apiUrl}/${eventId}`, { headers, observe: 'response', responseType: 'text' })
+      .pipe(map(() => undefined));
+  }
 }


### PR DESCRIPTION
## Summary
Integrated delete event functionality with backend API to allow users to remove events they created.

## Changes

- Connected delete action to `DELETE /api/events/:id` endpoint
- Added authentication token to request headers
- Displayed delete button only for events owned by the logged-in user
- Implemented confirmation dialog before deletion
- Removed event from UI after successful delete
- Added error handling for failed or unauthorized requests

## Behavior/Features

- Users can delete their own events
- Confirmation is required before deletion
- UI updates immediately after successful deletion
- Errors are handled and displayed appropriately

## Preview

<img width="1915" height="791" alt="Screenshot 2026-04-28 at 12 14 19 AM" src="https://github.com/user-attachments/assets/93247b33-540e-4976-9378-9f2714fc6f87" />


Closes #107 