### PR TITLE
feat: add pagination for events and announcements endpoints

### DIFF
--- a/backend/controllers/announcement_controller.go
+++ b/backend/controllers/announcement_controller.go
@@ -11,16 +11,22 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GetAnnouncements returns a paginated list of announcements.
+// Supports ?page=1&limit=10 query parameters.
 func GetAnnouncements(c *gin.Context) {
+	params := utils.ParsePagination(c)
 	var announcements []models.Announcement
 
-	if err := database.DB.Find(&announcements).Error; err != nil {
+	baseQuery := database.DB.Model(&models.Announcement{})
+
+	result, err := utils.Paginate(baseQuery, params, &announcements)
+	if err != nil {
 		utils.RespondWithError(c, utils.InternalServerError("Failed to fetch announcements"), "error", err)
 		return
 	}
 
-	slog.Info("Announcements fetched", "count", len(announcements))
-	c.JSON(http.StatusOK, announcements)
+	slog.Info("Announcements fetched", "count", len(announcements), "page", params.Page, "limit", params.Limit)
+	c.JSON(http.StatusOK, result)
 }
 
 func CreateAnnouncement(c *gin.Context) {

--- a/backend/controllers/controllers_test.go
+++ b/backend/controllers/controllers_test.go
@@ -97,8 +97,23 @@ func TestGetAnnouncements(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-	if !bytes.Contains(w.Body.Bytes(), []byte(`"title":"T1"`)) {
-		t.Fatalf("expected announcement in response body: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v body=%s", err, w.Body.String())
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		t.Fatalf("expected 'data' array in response: %s", w.Body.String())
+	}
+	if len(data) != 1 {
+		t.Fatalf("expected 1 announcement in data, got %d", len(data))
+	}
+
+	first := data[0].(map[string]interface{})
+	if first["title"] != "T1" {
+		t.Fatalf("expected title 'T1', got %v", first["title"])
 	}
 }
 
@@ -240,13 +255,21 @@ func TestGetEvents_EmptyList(t *testing.T) {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
 
-	var events []models.Event
-	if err := json.Unmarshal(w.Body.Bytes(), &events); err != nil {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v body=%s", err, w.Body.String())
 	}
 
-	if len(events) != 0 {
-		t.Fatalf("expected empty array, got %d events", len(events))
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		t.Fatalf("expected 'data' array in response: %s", w.Body.String())
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected empty data array, got %d events", len(data))
+	}
+
+	if resp["total"].(float64) != 0 {
+		t.Fatalf("expected total 0, got %v", resp["total"])
 	}
 }
 
@@ -273,18 +296,26 @@ func TestGetEvents_SortedByCreatedAtDesc(t *testing.T) {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
 
-	var events []models.Event
-	if err := json.Unmarshal(w.Body.Bytes(), &events); err != nil {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 
-	if len(events) != 3 {
-		t.Fatalf("expected 3 events, got %d", len(events))
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		t.Fatalf("expected 'data' array in response: %s", w.Body.String())
+	}
+
+	if len(data) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(data))
 	}
 
 	// Verify sorted by created_at desc (most recent first)
-	if events[0].Title != "Event 3" || events[1].Title != "Event 2" || events[2].Title != "Event 1" {
-		t.Fatalf("events not sorted correctly by created_at desc: %v", events)
+	first := data[0].(map[string]interface{})
+	second := data[1].(map[string]interface{})
+	third := data[2].(map[string]interface{})
+	if first["title"] != "Event 3" || second["title"] != "Event 2" || third["title"] != "Event 1" {
+		t.Fatalf("events not sorted correctly by created_at desc")
 	}
 }
 
@@ -550,3 +581,189 @@ func TestCreateEvent_WithoutImage_Optional(t *testing.T) {
 		t.Fatalf("expected image_url to be empty, got %q", created.ImageURL)
 	}
 }
+
+// Pagination Tests — Events
+
+func seedEvents(t *testing.T, count int) {
+	t.Helper()
+	for i := 1; i <= count; i++ {
+		evt := models.Event{
+			Title:    fmt.Sprintf("Event %d", i),
+			Date:     "2026-05-01",
+			Time:     "10:00",
+			Location: "Venue",
+			Author:   "user1",
+		}
+		if err := database.DB.Create(&evt).Error; err != nil {
+			t.Fatalf("seed event %d failed: %v", i, err)
+		}
+	}
+}
+
+func TestGetEvents_Pagination_DefaultParams(t *testing.T) {
+	setupControllerTestDB(t)
+	seedEvents(t, 15) // more than default limit of 10
+
+	r := gin.New()
+	r.GET("/api/events", GetEvents)
+
+	w := performJSONRequest(r, http.MethodGet, "/api/events", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	data := resp["data"].([]interface{})
+	if len(data) != 10 {
+		t.Fatalf("expected 10 events (default limit), got %d", len(data))
+	}
+	if int(resp["page"].(float64)) != 1 {
+		t.Fatalf("expected page 1, got %v", resp["page"])
+	}
+	if int(resp["total"].(float64)) != 15 {
+		t.Fatalf("expected total 15, got %v", resp["total"])
+	}
+	if int(resp["total_pages"].(float64)) != 2 {
+		t.Fatalf("expected total_pages 2, got %v", resp["total_pages"])
+	}
+}
+
+func TestGetEvents_Pagination_CustomPage(t *testing.T) {
+	setupControllerTestDB(t)
+	seedEvents(t, 5)
+
+	r := gin.New()
+	r.GET("/api/events", GetEvents)
+
+	w := performJSONRequest(r, http.MethodGet, "/api/events?page=2&limit=2", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	data := resp["data"].([]interface{})
+	if len(data) != 2 {
+		t.Fatalf("expected 2 events on page 2 with limit 2, got %d", len(data))
+	}
+	if int(resp["page"].(float64)) != 2 {
+		t.Fatalf("expected page 2, got %v", resp["page"])
+	}
+	if int(resp["total"].(float64)) != 5 {
+		t.Fatalf("expected total 5, got %v", resp["total"])
+	}
+	if int(resp["total_pages"].(float64)) != 3 {
+		t.Fatalf("expected total_pages 3, got %v", resp["total_pages"])
+	}
+}
+
+func TestGetEvents_Pagination_BeyondLastPage(t *testing.T) {
+	setupControllerTestDB(t)
+	seedEvents(t, 3)
+
+	r := gin.New()
+	r.GET("/api/events", GetEvents)
+
+	w := performJSONRequest(r, http.MethodGet, "/api/events?page=10&limit=5", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	data := resp["data"].([]interface{})
+	if len(data) != 0 {
+		t.Fatalf("expected 0 events beyond last page, got %d", len(data))
+	}
+	if int(resp["total"].(float64)) != 3 {
+		t.Fatalf("expected total 3, got %v", resp["total"])
+	}
+}
+
+// Pagination Tests — Announcements
+
+func seedAnnouncements(t *testing.T, count int) {
+	t.Helper()
+	for i := 1; i <= count; i++ {
+		ann := models.Announcement{
+			Title:   fmt.Sprintf("Announcement %d", i),
+			Content: fmt.Sprintf("Content %d", i),
+			Author:  "user1",
+		}
+		if err := database.DB.Create(&ann).Error; err != nil {
+			t.Fatalf("seed announcement %d failed: %v", i, err)
+		}
+	}
+}
+
+func TestGetAnnouncements_Pagination_DefaultParams(t *testing.T) {
+	setupControllerTestDB(t)
+	seedAnnouncements(t, 12)
+
+	r := gin.New()
+	r.GET("/api/announcements", GetAnnouncements)
+
+	w := performJSONRequest(r, http.MethodGet, "/api/announcements", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	data := resp["data"].([]interface{})
+	if len(data) != 10 {
+		t.Fatalf("expected 10 announcements (default limit), got %d", len(data))
+	}
+	if int(resp["total"].(float64)) != 12 {
+		t.Fatalf("expected total 12, got %v", resp["total"])
+	}
+	if int(resp["total_pages"].(float64)) != 2 {
+		t.Fatalf("expected total_pages 2, got %v", resp["total_pages"])
+	}
+}
+
+func TestGetAnnouncements_Pagination_CustomPage(t *testing.T) {
+	setupControllerTestDB(t)
+	seedAnnouncements(t, 7)
+
+	r := gin.New()
+	r.GET("/api/announcements", GetAnnouncements)
+
+	w := performJSONRequest(r, http.MethodGet, "/api/announcements?page=2&limit=3", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	data := resp["data"].([]interface{})
+	if len(data) != 3 {
+		t.Fatalf("expected 3 announcements on page 2 with limit 3, got %d", len(data))
+	}
+	if int(resp["page"].(float64)) != 2 {
+		t.Fatalf("expected page 2, got %v", resp["page"])
+	}
+	if int(resp["total"].(float64)) != 7 {
+		t.Fatalf("expected total 7, got %v", resp["total"])
+	}
+	if int(resp["total_pages"].(float64)) != 3 {
+		t.Fatalf("expected total_pages 3, got %v", resp["total_pages"])
+	}
+}
+

--- a/backend/controllers/event_controller.go
+++ b/backend/controllers/event_controller.go
@@ -19,17 +19,22 @@ import (
 
 const MaxUploadSize = 5 * 1024 * 1024 // 5 MB
 
-// GetEvents returns all events ordered by newest first.
+// GetEvents returns a paginated list of events ordered by newest first.
+// Supports ?page=1&limit=10 query parameters.
 func GetEvents(c *gin.Context) {
+	params := utils.ParsePagination(c)
 	var events []models.Event
 
-	if err := database.DB.Order("created_at desc").Find(&events).Error; err != nil {
+	baseQuery := database.DB.Model(&models.Event{}).Order("created_at desc")
+
+	result, err := utils.Paginate(baseQuery, params, &events)
+	if err != nil {
 		utils.RespondWithError(c, utils.InternalServerError("Failed to fetch events"), "error", err)
 		return
 	}
 
-	slog.Info("Events fetched", "count", len(events))
-	c.JSON(http.StatusOK, events)
+	slog.Info("Events fetched", "count", len(events), "page", params.Page, "limit", params.Limit)
+	c.JSON(http.StatusOK, result)
 }
 
 // CreateEvent handles multipart/form-data to create an event with an optional image upload.

--- a/backend/utils/pagination.go
+++ b/backend/utils/pagination.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// PaginationParams holds the parsed page and limit values from query strings.
+type PaginationParams struct {
+	Page  int `json:"page"`
+	Limit int `json:"limit"`
+}
+
+// PaginatedResponse wraps a paginated result set with metadata.
+type PaginatedResponse struct {
+	Data       interface{} `json:"data"`
+	Page       int         `json:"page"`
+	Limit      int         `json:"limit"`
+	Total      int64       `json:"total"`
+	TotalPages int         `json:"total_pages"`
+}
+
+const (
+	DefaultPage  = 1
+	DefaultLimit = 10
+	MaxLimit     = 100
+)
+
+// ParsePagination reads "page" and "limit" query parameters from the request
+// and returns clamped, validated PaginationParams.
+func ParsePagination(c *gin.Context) PaginationParams {
+	page := DefaultPage
+	limit := DefaultLimit
+
+	if p := c.Query("page"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil && v > 0 {
+			page = v
+		}
+	}
+
+	if l := c.Query("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+
+	// Clamp limit to MaxLimit
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+
+	return PaginationParams{Page: page, Limit: limit}
+}
+
+// Paginate executes a count query and a paginated find on the provided *gorm.DB.
+// The baseQuery should already have any Where/Order clauses applied.
+// dest must be a pointer to a slice (e.g., *[]models.Event).
+func Paginate(baseQuery *gorm.DB, params PaginationParams, dest interface{}) (*PaginatedResponse, error) {
+	var total int64
+
+	// Count total matching records (without offset/limit)
+	if err := baseQuery.Count(&total).Error; err != nil {
+		return nil, err
+	}
+
+	// Calculate offset
+	offset := (params.Page - 1) * params.Limit
+
+	// Fetch the page of results
+	if err := baseQuery.Offset(offset).Limit(params.Limit).Find(dest).Error; err != nil {
+		return nil, err
+	}
+
+	totalPages := int(math.Ceil(float64(total) / float64(params.Limit)))
+
+	return &PaginatedResponse{
+		Data:       dest,
+		Page:       params.Page,
+		Limit:      params.Limit,
+		Total:      total,
+		TotalPages: totalPages,
+	}, nil
+}

--- a/backend/utils/pagination_test.go
+++ b/backend/utils/pagination_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func createTestContext(queryString string) *gin.Context {
+	req := httptest.NewRequest(http.MethodGet, "/test?"+queryString, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	return c
+}
+
+func TestParsePagination_Defaults(t *testing.T) {
+	c := createTestContext("")
+	params := ParsePagination(c)
+
+	if params.Page != DefaultPage {
+		t.Errorf("expected default page %d, got %d", DefaultPage, params.Page)
+	}
+	if params.Limit != DefaultLimit {
+		t.Errorf("expected default limit %d, got %d", DefaultLimit, params.Limit)
+	}
+}
+
+func TestParsePagination_CustomValues(t *testing.T) {
+	c := createTestContext("page=3&limit=25")
+	params := ParsePagination(c)
+
+	if params.Page != 3 {
+		t.Errorf("expected page 3, got %d", params.Page)
+	}
+	if params.Limit != 25 {
+		t.Errorf("expected limit 25, got %d", params.Limit)
+	}
+}
+
+func TestParsePagination_NegativePageClampedToDefault(t *testing.T) {
+	c := createTestContext("page=-5&limit=10")
+	params := ParsePagination(c)
+
+	if params.Page != DefaultPage {
+		t.Errorf("expected page to be clamped to %d, got %d", DefaultPage, params.Page)
+	}
+}
+
+func TestParsePagination_ZeroPageClampedToDefault(t *testing.T) {
+	c := createTestContext("page=0&limit=10")
+	params := ParsePagination(c)
+
+	if params.Page != DefaultPage {
+		t.Errorf("expected page to be clamped to %d, got %d", DefaultPage, params.Page)
+	}
+}
+
+func TestParsePagination_LimitClampedToMax(t *testing.T) {
+	c := createTestContext("page=1&limit=500")
+	params := ParsePagination(c)
+
+	if params.Limit != MaxLimit {
+		t.Errorf("expected limit to be clamped to %d, got %d", MaxLimit, params.Limit)
+	}
+}
+
+func TestParsePagination_InvalidStringsUseDefaults(t *testing.T) {
+	c := createTestContext("page=abc&limit=xyz")
+	params := ParsePagination(c)
+
+	if params.Page != DefaultPage {
+		t.Errorf("expected default page %d, got %d", DefaultPage, params.Page)
+	}
+	if params.Limit != DefaultLimit {
+		t.Errorf("expected default limit %d, got %d", DefaultLimit, params.Limit)
+	}
+}
+
+func TestParsePagination_NegativeLimitClampedToDefault(t *testing.T) {
+	c := createTestContext("page=1&limit=-10")
+	params := ParsePagination(c)
+
+	if params.Limit != DefaultLimit {
+		t.Errorf("expected limit to be clamped to %d, got %d", DefaultLimit, params.Limit)
+	}
+}


### PR DESCRIPTION
- Add shared pagination utility (utils/pagination.go) with ParsePagination and Paginate helpers supporting page/limit query params
- Update GetEvents to return paginated response with data, page, limit, total, and total_pages fields (default: page=1, limit=10)
- Update GetAnnouncements with same pagination envelope
- Add unit tests for pagination utility (7 tests)
- Add pagination integration tests for events (3 tests) and announcements (2 tests)
- Update existing GetEvents/GetAnnouncements tests for new envelope format

Closes #103